### PR TITLE
Make the dependency to native-tls optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "0.4.1"
 futures = "0.1"
 lazy_static = "0.2.4"
 log = "0.3.6"
-native-tls = "0.1.1"
+native-tls = { version = "0.1.1", optional = true }
 nom = "2.0"
 tokio-core = "0.1"
 tokio-io = "0.1.1"
@@ -34,13 +34,15 @@ version = "0.1.4"
 [dependencies.tokio-tls]
 features = ["tokio-proto"]
 version = "0.1.2"
+optional = true
 
 [dependencies.clippy]
 version = "0.0.129"
 optional = true
 
 [features]
-default = []
+default = ["tls"]
+tls = ["native-tls", "tokio-tls"]
 
 [dev-dependencies]
 env_logger = "0.4.2"

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -392,6 +392,7 @@ impl LdapConnAsync {
         let mut port = 389;
         let scheme = match url.scheme() {
             s @ "ldap" => s,
+            #[cfg(feature = "tls")]
             s @ "ldaps" => { port = 636; s },
             s => return Err(io::Error::new(io::ErrorKind::Other, format!("unimplemented LDAP URL scheme: {}", s))),
         };

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -45,6 +45,7 @@ impl LdapWrapper {
         Box::new(lw)
     }
 
+    #[cfg(feature = "tls")]
     fn connect_ssl(addr: &str, handle: &Handle) -> Box<Future<Item=LdapWrapper, Error=io::Error>> {
         let lw = Ldap::connect_ssl(addr, handle)
             .map(|ldap| {
@@ -418,6 +419,7 @@ impl LdapConnAsync {
         Ok(LdapConnAsync {
             in_progress: match scheme {
                 "ldap" => LdapWrapper::connect(&addr.expect("addr"), handle).shared(),
+                #[cfg(feature = "tls")]
                 "ldaps" => LdapWrapper::connect_ssl(&host_port, handle).shared(),
                 _ => unimplemented!(),
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ extern crate lazy_static;
 extern crate lber;
 #[macro_use]
 extern crate log;
+#[cfg(feature = "tls")]
 extern crate native_tls;
 #[macro_use]
 extern crate nom;
@@ -51,6 +52,7 @@ extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_proto;
 extern crate tokio_service;
+#[cfg(feature = "tls")]
 extern crate tokio_tls;
 #[cfg(unix)]
 extern crate tokio_uds;


### PR DESCRIPTION
This pull request adds a feature `tls` (enabled by default) which gates the `connect_ssl()` functions. By building without this feature, one can avoid dependency to native TLS libraries caused by `native-tls` which may not be statically linkable (or simply unnecessary if TLS support is not required).