### PR TITLE
Add a missing #[cfg(unix)]

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -56,6 +56,7 @@ impl LdapWrapper {
         Box::new(lw)
     }
 
+    #[cfg(unix)]
     fn connect_unix(path: &str, handle: &Handle) -> Box<Future<Item=LdapWrapper, Error=io::Error>> {
         let lw = Ldap::connect_unix(path, handle)
             .map(|ldap| {


### PR DESCRIPTION
LdapWrapper::connect_unix was missing a #[cfg(unix)], causing the build to fail on Windows. With this change the build is successful.