### PR TITLE
Implemented connecting with an external TlsConnector.

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -529,8 +529,9 @@ impl<T> LdapConnBuilder<T> {
         self
     }
 
+    #[doc(hidden)]
     /// Provide a connector that is used to establish TLS connections.
-    pub fn with_connector(mut self, connector: TlsConnector) -> Self {
+    pub fn with_tls_connector(mut self, connector: TlsConnector) -> Self {
         self.connector = Some(connector);
         self
     }

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -169,6 +169,41 @@ impl Ldap {
         connect_with_timeout(timeout, Box::new(ret), handle)
     }
 
+    /// Connect to an LDAP server with an attempt to negotiate TLS immediately after
+    /// establishing the TCP connection, using the host name and port number in `addr`,
+    /// and an event loop handle in `handle`. If `timeout` is not `None`, it specifies
+    /// how long the connection attempt will take before returning an error.
+    ///
+    /// The connection _must_ be by host name for TLS hostname check to work.
+    #[cfg(feature = "tls")]
+    pub fn connect_ssl_with_connector(addr: &str, handle: &Handle, timeout: Option<Duration>, connector: TlsConnector) ->
+            Box<Future<Item=Ldap, Error=io::Error>> {
+        if addr.parse::<SocketAddr>().ok().is_some() {
+            return Box::new(future::err(io::Error::new(io::ErrorKind::Other, "SSL connection must be by hostname")));
+        }
+        let sockaddr = addr.to_socket_addrs().unwrap_or_else(|_| vec![].into_iter()).next();
+        if sockaddr.is_none() {
+            return Box::new(future::err(io::Error::new(io::ErrorKind::Other, "no addresses found")));
+        }
+        let proto = LdapProto::new(handle.clone());
+        let bundle = proto.bundle();
+        let wrapper = TlsClient::new(proto,
+            connector,
+            addr.split(':').next().expect("hostname"));
+        let ret = TcpClient::new(wrapper)
+            .connect(&sockaddr.unwrap(), handle)
+            .map(|client_proxy| {
+                Ldap {
+                    inner: ClientMap::Tls(client_proxy),
+                    bundle: bundle,
+                    next_search_options: Rc::new(RefCell::new(None)),
+                    next_req_controls: Rc::new(RefCell::new(None)),
+                    next_timeout: Rc::new(RefCell::new(None)),
+                }
+            });
+        connect_with_timeout(timeout, Box::new(ret), handle)
+    }
+
     /// Connect to an LDAP server through a Unix domain socket, using the path
     /// in `path`, and an event loop handle in `handle`.
     #[cfg(all(unix, not(feature = "minimal")))]

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -176,7 +176,7 @@ impl Ldap {
     ///
     /// The connection _must_ be by host name for TLS hostname check to work.
     #[cfg(feature = "tls")]
-    pub fn connect_ssl_with_connector(addr: &str, handle: &Handle, timeout: Option<Duration>, connector: TlsConnector) ->
+    fn connect_ssl_with_connector(addr: &str, handle: &Handle, timeout: Option<Duration>, connector: TlsConnector) ->
             Box<Future<Item=Ldap, Error=io::Error>> {
         if addr.parse::<SocketAddr>().ok().is_some() {
             return Box::new(future::err(io::Error::new(io::ErrorKind::Other, "SSL connection must be by hostname")));


### PR DESCRIPTION
This is a backwards-compatible change. I didn't change any public interfaces.

I added two methods: `with_connector` on `LdapConnBuilder ` and `connect_ssl_with_connector ` on `Ldap`. (The latter mirrors the already existing method method `connect_ssl`, which I couldn't change)

It's now possible to provide a `TlsConnector` of `native-tls` crate, that builds the connection. This allows using self-signed certificates, because you can use them providing the certifate with `add_root_certificate` method.

Fixes https://github.com/inejge/ldap3/issues/10