### PR TITLE
The most significant bit in a INTEGER is always 0

### DIFF
--- a/lber/src/structures/integer.rs
+++ b/lber/src/structures/integer.rs
@@ -28,6 +28,13 @@ fn i_e_into_structure(id: u64, class: TagClass, inner: i64) -> structure::Struct
     let mut rem: i64 = if inner >= 0 { inner } else { inner * -1 };
     while {count += 1; rem >>= 8; rem > 0 }{}
 
+    // Ensure that the most significant bit is always 0, because BER uses signed numbers.
+    // We shift away all but the most significant bit and check that.
+    // See #21
+    if inner > 0 && inner >> ((8 * count) - 1) == 1 {
+        count += 1;
+    }
+
     let mut out: Vec<u8> = Vec::with_capacity(count as usize);
 
     out.write_int::<BigEndian>(inner, count as usize).unwrap();
@@ -68,5 +75,30 @@ impl default::Default for Enumerated {
             class: TagClass::Universal,
             inner: 0i64,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::i_e_into_structure;
+
+    use common::TagClass;
+    use structure;
+
+    #[test]
+    fn test_not_unnecessary_octets() {
+        // 127 can be encoded into 8 bits
+        let result = i_e_into_structure(2, TagClass::Universal, 127);
+        let correct = structure::PL::P(vec![127]);
+        assert_eq![result.payload, correct];
+    }
+
+    #[test]
+    fn test_not_positive_getting_negative() {
+        // 128 can be encoded cannot be encoded into a 8 bit signed number
+        // See #21
+        let result = i_e_into_structure(2, TagClass::Universal, 128);
+        let correct = structure::PL::P(vec![0, 128]);
+        assert_eq![result.payload, correct];
     }
 }

--- a/lber/src/write.rs
+++ b/lber/src/write.rs
@@ -116,13 +116,9 @@ fn write_length(w: &mut Write, length: usize) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use std::string;
-
     use std::default::Default;
 
-    use byteorder::{BigEndian, WriteBytesExt};
+    use bytes::BytesMut;
 
     use structures::*;
     use common::TagClass::*;
@@ -134,8 +130,8 @@ mod tests {
             .. Default::default()
         });
 
-        let mut buf = Vec::<u8>::new();
-        super::encode_into(&mut buf, tag.into_structure());
+        let mut buf = BytesMut::new();
+        super::encode_into(&mut buf, tag.into_structure()).unwrap();
 
         assert_eq!(buf, vec![0x2, 0x2, 0x06, 0x50]);
     }
@@ -153,8 +149,8 @@ mod tests {
             .. Default::default()
         });
 
-        let mut buf = Vec::<u8>::new();
-        super::encode_into(&mut buf, tag.into_structure());
+        let mut buf = BytesMut::new();
+        super::encode_into(&mut buf, tag.into_structure()).unwrap();
 
         assert_eq!(buf, vec![48,14,4,12,72,101,108,108,111,32,87,111,114,108,100,33]);
     }
@@ -200,8 +196,8 @@ mod tests {
                     0x80, 0x04, 0x61, 0x73, 0x64, 0x66
         ];
 
-        let mut buf = Vec::<u8>::new();
-        super::encode_into(&mut buf, tag.into_structure());
+        let mut buf = BytesMut::new();
+        super::encode_into(&mut buf, tag.into_structure()).unwrap();
 
         assert_eq!(buf, expected);
     }


### PR DESCRIPTION
When the number is positive.

If a INTEGER is only decoded with 8 bits one octet, and the
msb of that octet is 1, AD reads this as a signed integer,
and will therefore read a negative number.

This fixes that by incrementing the number of octets in a integer
if the msb is 1 and the number is positive.

Fixes #21

(I also fixed a few tests that failed)