### PR TITLE
Bump native-tls dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ version = "0.6.0"
 byteorder = "1.0.0"
 bytes = "0.4.1"
 futures = "0.1.15"
-lazy_static = "0.2.4"
-log = "0.3.6"
-native-tls = { version = "0.1.3", optional = true }
+lazy_static = "1.1"
+log = "0.4"
+native-tls = { version = "0.2", optional = true }
 nom = "2.0"
 tokio-core = "0.1"
 tokio-io = "0.1.1"
@@ -32,11 +32,7 @@ path = "lber"
 version = "0.1.6"
 
 [dependencies.tokio-tls]
-version = "0.1.3"
-optional = true
-
-[dependencies.clippy]
-version = "0.0.129"
+version = "0.2"
 optional = true
 
 [features]
@@ -45,11 +41,8 @@ tls = ["native-tls", "tokio-tls"]
 minimal = []
 
 [dev-dependencies]
-env_logger = "0.4.2"
-maplit = "0.1.4"
-
-[target.'cfg(all(unix, not(target_os = "macos")))'.dev-dependencies]
-openssl = "0.9"
+env_logger = "0.5"
+maplit = "1.0"
 
 [workspace]
 members = [".", "lber"]

--- a/examples/connect_tls_ipaddr.rs
+++ b/examples/connect_tls_ipaddr.rs
@@ -15,16 +15,10 @@ fn main() {
     }
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
 fn custom_connector() -> Result<TlsConnector, Box<Error>> {
     let mut builder = TlsConnector::builder();
     builder.danger_accept_invalid_certs(true);
     Ok(builder.build()?)
-}
-
-#[cfg(any(not(unix), target_os = "macos"))]
-fn custom_connector() -> Result<TlsConnector, Box<Error>> {
-    Ok(TlsConnector::builder()?.build()?)
 }
 
 fn do_tls_conn() -> Result<(), Box<Error>> {

--- a/examples/connect_tls_ipaddr.rs
+++ b/examples/connect_tls_ipaddr.rs
@@ -1,7 +1,5 @@
 extern crate ldap3;
 extern crate native_tls;
-#[cfg(all(unix, not(target_os = "macos")))]
-extern crate openssl;
 extern crate env_logger;
 
 use std::error::Error;
@@ -19,11 +17,8 @@ fn main() {
 
 #[cfg(all(unix, not(target_os = "macos")))]
 fn custom_connector() -> Result<TlsConnector, Box<Error>> {
-    use native_tls::backend::openssl::TlsConnectorBuilderExt;
-    use openssl::ssl::SSL_VERIFY_NONE;
-
-    let mut builder = TlsConnector::builder()?;
-    builder.builder_mut().builder_mut().set_verify(SSL_VERIFY_NONE);
+    let mut builder = TlsConnector::builder();
+    builder.danger_accept_invalid_certs(true);
     Ok(builder.build()?)
 }
 

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -148,12 +148,19 @@ impl Ldap {
         let bundle = proto.bundle();
         let connector = match settings.connector {
             Some(connector) => connector,
-            None => TlsConnector::builder().expect("tls_builder").build().expect("connector"),
+            None => {
+                let mut builder = TlsConnector::builder();
+
+                if settings.no_tls_verify {
+                    builder.danger_accept_invalid_certs(true);
+                }
+
+                builder.build().expect("connector")
+            },
         };
         let wrapper = TlsClient::new(proto,
             connector,
             settings.starttls,
-            settings.no_tls_verify,
             hostname);
         let ret = TcpClient::new(wrapper)
             .connect(addr, handle)


### PR DESCRIPTION
- Refactors the tls code to native-tls 0.2 and tokio-tls 0.2.
- Some easy dependency bumps
- Drop the clippy dependency, `rustup component add clippy-preview --toolchain=nightly` is the recommended way to run clippy right now