### PR TITLE
Make tokio-uds optional to exclude it from minimal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,9 @@ tokio-core = "0.1"
 tokio-io = "0.1.1"
 tokio-proto = "0.1"
 tokio-service = "0.1"
+tokio-uds = { version = "0.1.4" , optional = true }
+tokio-uds-proto = { version = "0.1", optional = true }
 url = "1.4.0"
-
-[target.'cfg(all(unix, not(feature = "minimal")))'.dependencies]
-tokio-uds = "0.1.4" 
-tokio-uds-proto = "0.1"
 
 [dependencies.lber]
 path = "lber"
@@ -37,8 +35,9 @@ version = "0.2"
 optional = true
 
 [features]
-default = ["tls"]
+default = ["tls", "uds"]
 tls = ["native-tls", "tokio-tls"]
+uds = ["tokio-uds", "tokio-uds-proto"]
 minimal = []
 
 [dev-dependencies]


### PR DESCRIPTION
The used version of tokio-uds is not compiling under OpenBSD, the fix in HEAD never made it into a newer release, and I also don't need UDS in my specific use case. The "minimal" feature would be a good solution but the current Cargo.toml configuration of ldap3 does not make tokio-uds optional, in fact it always compiles it no matter of the features configuration.
