### PR TITLE
Add support for GSS-SPNEGO bind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ tokio-uds-proto = "0.1"
 path = "lber"
 version = "0.1.6"
 
+[dependencies.sspi]
+version = "0.1.0"
+
 [dependencies.tokio-tls]
 version = "0.2"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ path = "lber"
 version = "0.1.6"
 
 [dependencies.sspi]
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies.tokio-tls]
 version = "0.2"

--- a/examples/connect_spnego.rs
+++ b/examples/connect_spnego.rs
@@ -1,0 +1,26 @@
+extern crate ldap3;
+
+use std::error::Error;
+use std::env;
+
+use ldap3::LdapConn;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let server_url = args.get(1).unwrap();
+    let username = args.get(2).unwrap();
+    let password = args.get(3).unwrap();
+
+    println!("server_url: {} username: {} password: {}", server_url, username, password);
+
+    match do_connection(server_url, username, password) {
+        Ok(_) => (),
+        Err(e) => println!("{:?}", e),
+    }
+}
+
+fn do_connection(server_url: &str, username: &str, password: &str) -> Result<(), Box<Error>> {
+    let ldap = LdapConn::new(server_url)?;
+    let _response = ldap.sasl_spnego_bind(username, password)?.success()?;
+    Ok(())
+}

--- a/src/bind_spnego.rs
+++ b/src/bind_spnego.rs
@@ -1,0 +1,80 @@
+use std::io;
+
+use lber::structures::{Tag, Sequence, Integer, OctetString};
+use lber::common::TagClass;
+
+use futures::{Future};
+use tokio_service::Service;
+
+use ldap::{Ldap, LdapOp, next_req_controls};
+use result::LdapResult;
+
+use spnego;
+
+pub const GSS_SPNEGO: &'static str = "GSS-SPNEGO";
+
+fn create_bind_request(token: Vec<u8>) -> Tag {
+    Tag::Sequence(Sequence {
+        id: 0,
+        class: TagClass::Application,
+        inner: vec![
+            Tag::Integer(Integer {
+                inner: 3,
+                .. Default::default()
+            }),
+            Tag::OctetString(OctetString {
+                inner: Vec::new(),
+                .. Default::default()
+            }),
+            Tag::Sequence(Sequence {
+                id: 3,
+                class: TagClass::Context,
+                inner: vec![
+                    Tag::OctetString(OctetString {
+                        inner: Vec::from(GSS_SPNEGO),
+                        .. Default::default()
+                    }),
+                    Tag::OctetString(OctetString {
+                        inner: token.to_vec(),
+                        .. Default::default()
+                    }),
+                ]
+            })
+        ],
+    })
+}
+
+impl Ldap {
+    /// See [`LdapConn::sasl_spnego_bind()`](struct.LdapConn.html#method.sasl_spnego_bind).
+    pub fn sasl_spnego_bind(&self, username: &str, password: &str) ->
+    Box<Future<Item=LdapResult, Error=io::Error>> {
+        let mut spnego_client = spnego::Client::new(username, password);
+
+        let input = Vec::new();
+        let mut output = Vec::new();
+        let _sspi_status = spnego_client.authenticate(input.as_slice(), &mut output).unwrap();
+        let req = create_bind_request(output.clone());
+
+        let ldap = self.clone();
+        let fut = self.call(LdapOp::Single(req, next_req_controls(self)))
+            .and_then(move |response| {
+
+                let (mut result, controls) = (LdapResult::from(response.0), response.1);
+                result.ctrls = controls;
+
+                let input = result.get_bind_token().unwrap();
+                let mut output = Vec::new();
+                let _sspi_status = spnego_client.authenticate(input.as_slice(), &mut output).unwrap();
+                let req = create_bind_request(output.clone());
+
+                ldap.call(LdapOp::Single(req, next_req_controls(&ldap)))
+                    .and_then(|response| {
+                        let (mut result, controls) = (LdapResult::from(response.0), response.1);
+                        result.ctrls = controls;
+                        Ok(result)
+                    })
+            });
+
+        Box::new(fut)
+    }
+}

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -229,6 +229,11 @@ impl LdapConn {
         Ok(self.core.borrow_mut().run(self.inner.clone().sasl_external_bind())?)
     }
 
+    /// Do a SASL GSS-SPNEGO bind (SSPI Negotiate module, NTLM or Kerberos)
+    pub fn sasl_spnego_bind(&self, username: &str, password: &str) -> io::Result<LdapResult> {
+        Ok(self.core.borrow_mut().run(self.inner.clone().sasl_spnego_bind(username, password))?)
+    }
+
     /// Use the provided `SearchOptions` with the next Search operation, which can
     /// be invoked directly on the result of this method. If this method is used in
     /// combination with a non-Search operation, the provided options will be silently

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,9 +138,13 @@ extern crate tokio_uds;
 extern crate tokio_uds_proto;
 extern crate url;
 
+extern crate sspi;
+mod spnego;
+
 mod abandon;
 mod add;
 mod bind;
+mod bind_spnego;
 mod compare;
 mod conn;
 pub mod controls {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -22,7 +22,7 @@ use lber::universal::Types;
 use lber::write;
 
 use controls::Control;
-use controls_impl::{parse_controls, build_tag};
+use controls_impl::{parse_controls, parse_bind_response, build_tag};
 use exop::Exop;
 use ldap::LdapOp;
 use result::LdapResult;
@@ -217,6 +217,11 @@ impl Decoder for LdapCodec {
                     helper.seen = true;
                     Ok(Some((id, (id_tag, vec![]))))
                 }
+            },
+            1 => {
+                let controls = parse_bind_response(protoop.clone());
+                self.bundle.borrow_mut().id_map.remove(&msgid);
+                Ok(Some((id, (Tag::StructureTag(protoop), controls))))
             },
             _ => {
                 self.bundle.borrow_mut().id_map.remove(&msgid);

--- a/src/spnego.rs
+++ b/src/spnego.rs
@@ -1,0 +1,23 @@
+use std::io;
+
+use sspi::ntlm::*;
+use sspi::sspi::{Sspi};
+
+pub struct Client {
+    sspi_module: Ntlm,
+}
+
+impl Client {
+    pub fn new(username: &str, password: &str) -> Self {
+        let credentials = sspi::Credentials::new(username.to_string(), password.to_string(), None);
+        let sspi_module = sspi::ntlm::Ntlm::new(Some(credentials));
+
+        Client {
+            sspi_module: sspi_module,
+        }
+    }
+
+    pub fn authenticate(&mut self, input: impl io::Read, output: impl io::Write) -> sspi::SspiResult {
+        self.sspi_module.initialize_security_context(input, output)
+    }
+}

--- a/src/spnego.rs
+++ b/src/spnego.rs
@@ -10,7 +10,9 @@ pub struct Client {
 impl Client {
     pub fn new(username: &str, password: &str) -> Self {
         let credentials = sspi::Credentials::new(username.to_string(), password.to_string(), None);
-        let sspi_module = sspi::ntlm::Ntlm::new(Some(credentials));
+        let mut sspi_module = sspi::ntlm::Ntlm::new(Some(credentials));
+        sspi_module.set_confidentiality(false);
+        sspi_module.set_integrity(false);
 
         Client {
             sspi_module: sspi_module,


### PR DESCRIPTION
This pull request adds support for the GSS-SPNEGO bind type with NTLM. There is no support for integrated Windows authentication or Kerberos at this point. This has been tested against Windows Active Directory, compared against sample Wireshark captures.