### PR TITLE
Use dyn for trait objects.

### DIFF
--- a/examples/add.rs
+++ b/examples/add.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 }
 
-fn do_add() -> Result<(), Box<Error>> {
+fn do_add() -> Result<(), Box<dyn Error>> {
     let ldap = LdapConn::new("ldap://localhost:2389")?;
     ldap.simple_bind("cn=Manager,dc=example,dc=org", "secret")?.success()?;
     let res = ldap.add(

--- a/examples/compare.rs
+++ b/examples/compare.rs
@@ -11,7 +11,7 @@ fn main() {
     }
 }
 
-fn do_compare() -> Result<bool, Box<Error>> {
+fn do_compare() -> Result<bool, Box<dyn Error>> {
     let ldap = LdapConn::new("ldap://localhost:2389")?;
     ldap.simple_bind("cn=Manager,dc=example,dc=org", "secret")?.success()?;
     let cmp = ldap.compare(

--- a/examples/connect_tls.rs
+++ b/examples/connect_tls.rs
@@ -11,7 +11,7 @@ fn main() {
     }
 }
 
-fn do_tls_conn() -> Result<(), Box<Error>> {
+fn do_tls_conn() -> Result<(), Box<dyn Error>> {
     let ldap = LdapConn::new("ldaps://ldap.example.com")?;
     ldap.simple_bind("cn=user,ou=People,dc=example,dc=com", "secret")?.success()?;
     Ok(())

--- a/examples/connect_tls_ipaddr.rs
+++ b/examples/connect_tls_ipaddr.rs
@@ -15,13 +15,13 @@ fn main() {
     }
 }
 
-fn custom_connector() -> Result<TlsConnector, Box<Error>> {
+fn custom_connector() -> Result<TlsConnector, Box<dyn Error>> {
     let mut builder = TlsConnector::builder();
     builder.danger_accept_invalid_certs(true);
     Ok(builder.build()?)
 }
 
-fn do_tls_conn() -> Result<(), Box<Error>> {
+fn do_tls_conn() -> Result<(), Box<dyn Error>> {
     let settings = LdapConnSettings::new()
         .set_no_tls_verify(true)
         .set_connector(custom_connector()?);

--- a/examples/delete.rs
+++ b/examples/delete.rs
@@ -11,7 +11,7 @@ fn main() {
     }
 }
 
-fn do_delete() -> Result<(), Box<Error>> {
+fn do_delete() -> Result<(), Box<dyn Error>> {
     let ldap = LdapConn::new("ldap://localhost:2389")?;
     ldap.simple_bind("cn=Manager,dc=example,dc=org", "secret")?.success()?;
     let res = ldap.delete("uid=extra,ou=People,dc=example,dc=org")?.success()?;

--- a/examples/moddn.rs
+++ b/examples/moddn.rs
@@ -11,7 +11,7 @@ fn main() {
     }
 }
 
-fn do_modifydn() -> Result<(), Box<Error>> {
+fn do_modifydn() -> Result<(), Box<dyn Error>> {
     let ldap = LdapConn::new("ldap://localhost:2389")?;
     ldap.simple_bind("cn=Manager,dc=example,dc=org", "secret")?.success()?;
     let res = ldap.modifydn(

--- a/examples/modify_relax.rs
+++ b/examples/modify_relax.rs
@@ -14,7 +14,7 @@ fn main() {
     }
 }
 
-fn do_modify() -> Result<(), Box<Error>> {
+fn do_modify() -> Result<(), Box<dyn Error>> {
     let ldap = LdapConn::new("ldap://localhost:2389")?;
     ldap.simple_bind("cn=Manager,dc=example,dc=org", "secret")?.success()?;
     let res = ldap

--- a/examples/search.rs
+++ b/examples/search.rs
@@ -11,7 +11,7 @@ fn main() {
     }
 }
 
-fn do_search() -> Result<(), Box<Error>> {
+fn do_search() -> Result<(), Box<dyn Error>> {
     let ldap = LdapConn::new("ldap://localhost:2389")?;
     let (rs, _) = ldap.search(
         "ou=Places,dc=example,dc=org",

--- a/examples/search_abandon.rs
+++ b/examples/search_abandon.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 }
 
-fn do_abandon() -> Result<LdapResult, Box<Error>> {
+fn do_abandon() -> Result<LdapResult, Box<dyn Error>> {
     let ldap = LdapConn::new("ldap://localhost:2389")?;
     let mut count = 0;
     let mut strm = ldap.streaming_search(

--- a/examples/search_autopage.rs
+++ b/examples/search_autopage.rs
@@ -11,7 +11,7 @@ fn main() {
     }
 }
 
-fn do_search() -> Result<u32, Box<Error>> {
+fn do_search() -> Result<u32, Box<dyn Error>> {
     let ldap = LdapConn::new("ldap://localhost:2389")?;
     let mut strm = ldap
         .with_search_options(SearchOptions::new().autopage(500))

--- a/examples/search_options.rs
+++ b/examples/search_options.rs
@@ -11,7 +11,7 @@ fn main() {
     }
 }
 
-fn do_search() -> Result<(), Box<Error>> {
+fn do_search() -> Result<(), Box<dyn Error>> {
     let ldap = LdapConn::new("ldap://localhost:2389")?;
     let (rs, res) = ldap
         .with_search_options(SearchOptions::new().sizelimit(1))

--- a/examples/search_streaming_paged.rs
+++ b/examples/search_streaming_paged.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 }
 
-fn do_search() -> Result<u32, Box<Error>> {
+fn do_search() -> Result<u32, Box<dyn Error>> {
     let ldap = LdapConn::new("ldap://localhost:2389")?;
     let mut cookie = Vec::new();
     let mut count = 0;

--- a/examples/search_timeout.rs
+++ b/examples/search_timeout.rs
@@ -12,7 +12,7 @@ fn main() {
     }
 }
 
-fn do_search() -> Result<(), Box<Error>> {
+fn do_search() -> Result<(), Box<dyn Error>> {
     let ldap = LdapConn::with_settings(
         LdapConnSettings::new().set_conn_timeout(Duration::from_secs(5)),
         "ldap://localhost:2389")?;

--- a/examples/whoami.rs
+++ b/examples/whoami.rs
@@ -12,7 +12,7 @@ fn main() {
     }
 }
 
-fn do_whoami() -> Result<String, Box<Error>> {
+fn do_whoami() -> Result<String, Box<dyn Error>> {
     let ldap = LdapConn::new("ldap://localhost:2389")?;
     ldap.simple_bind("cn=Manager,dc=example,dc=org", "secret")?.success()?;
     let (exop, _res) = ldap.extended(WhoAmI)?.success()?;

--- a/examples/whoami_external.rs
+++ b/examples/whoami_external.rs
@@ -12,7 +12,7 @@ fn main() {
     }
 }
 
-fn do_whoami() -> Result<String, Box<Error>> {
+fn do_whoami() -> Result<String, Box<dyn Error>> {
     let ldap = LdapConn::new("ldapi://ldapi")?;
     ldap.sasl_external_bind()?.success()?;
     let (exop, _res) = ldap.extended(WhoAmI)?.success()?;

--- a/examples/whoami_proxyauth.rs
+++ b/examples/whoami_proxyauth.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 }
 
-fn do_whoami() -> Result<String, Box<Error>> {
+fn do_whoami() -> Result<String, Box<dyn Error>> {
     let ldap = LdapConn::new("ldapi://ldapi")?;
     ldap.simple_bind("cn=proxy,dc=example,dc=org", "topsecret")?.success()?;
     let (exop, _res) = ldap

--- a/src/abandon.rs
+++ b/src/abandon.rs
@@ -17,7 +17,7 @@ impl Ldap {
     /// [`EntryStream::abandon()`](struct.EntryStream.html#method.abandon) and
     /// [`SearchStream::get_abandon_channel()`](struct.SearchStream.html#method.get_abandon_channel).
     pub fn abandon(&self, msgid: LdapRequestId) ->
-            Box<Future<Item=(), Error=io::Error>> {
+            Box<dyn Future<Item=(), Error=io::Error>> {
         let bundle = bundle(self);
         if !bundle.borrow().id_map.contains_key(&msgid) {
             return Box::new(future::err(io::Error::new(io::ErrorKind::Other, format!("msgid {} not an active operation", msgid))));

--- a/src/add.rs
+++ b/src/add.rs
@@ -15,7 +15,7 @@ use result::LdapResult;
 impl Ldap {
     /// See [`LdapConn::add()`](struct.LdapConn.html#method.add).
     pub fn add<S: AsRef<[u8]> + Eq + Hash>(&self, dn: &str, attrs: Vec<(S, HashSet<S>)>) ->
-            Box<Future<Item=LdapResult, Error=io::Error>> {
+            Box<dyn Future<Item=LdapResult, Error=io::Error>> {
         let mut any_empty = false;
         let req = Tag::Sequence(Sequence {
             id: 8,

--- a/src/bind.rs
+++ b/src/bind.rs
@@ -12,7 +12,7 @@ use result::LdapResult;
 impl Ldap {
     /// See [`LdapConn::simple_bind()`](struct.LdapConn.html#method.simple_bind).
     pub fn simple_bind(&self, bind_dn: &str, bind_pw: &str) ->
-            Box<Future<Item=LdapResult, Error=io::Error>> {
+            Box<dyn Future<Item=LdapResult, Error=io::Error>> {
         let req = Tag::Sequence(Sequence {
             id: 0,
             class: TagClass::Application,
@@ -46,7 +46,7 @@ impl Ldap {
     #[cfg(not(feature = "minimal"))]
     /// See [`LdapConn::sasl_external_bind()`](struct.LdapConn.html#method.sasl_external_bind).
     pub fn sasl_external_bind(&self) ->
-            Box<Future<Item=LdapResult, Error=io::Error>> {
+            Box<dyn Future<Item=LdapResult, Error=io::Error>> {
         let req = Tag::Sequence(Sequence {
             id: 0,
             class: TagClass::Application,

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -13,7 +13,7 @@ use result::{CompareResult, LdapResult};
 impl Ldap {
     /// See [`LdapConn::compare()`](struct.LdapConn.html#method.compare).
     pub fn compare<B: AsRef<[u8]>>(&self, dn: &str, attr: &str, val: B) ->
-            Box<Future<Item=CompareResult, Error=io::Error>> {
+            Box<dyn Future<Item=CompareResult, Error=io::Error>> {
         let req = Tag::Sequence(Sequence {
             id: 14,
             class: TagClass::Application,

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -35,8 +35,8 @@ impl LdapWrapper {
         self.inner.clone()
     }
 
-    fn connect(addr: Box<Future<Item=SocketAddr, Error=io::Error>>, handle: &Handle, settings: LdapConnSettings)
-        -> Box<Future<Item=LdapWrapper, Error=io::Error>>
+    fn connect(addr: Box<dyn Future<Item=SocketAddr, Error=io::Error>>, handle: &Handle, settings: LdapConnSettings)
+        -> Box<dyn Future<Item=LdapWrapper, Error=io::Error>>
     {
         let handle = handle.clone();
         let lw = addr.and_then(move |addr| Ldap::connect(&addr, &handle, settings))
@@ -49,8 +49,8 @@ impl LdapWrapper {
     }
 
     #[cfg(feature = "tls")]
-    fn connect_ssl(addr: Box<Future<Item=SocketAddr, Error=io::Error>>, hostname: &str, handle: &Handle, settings: LdapConnSettings)
-        -> Box<Future<Item=LdapWrapper, Error=io::Error>>
+    fn connect_ssl(addr: Box<dyn Future<Item=SocketAddr, Error=io::Error>>, hostname: &str, handle: &Handle, settings: LdapConnSettings)
+        -> Box<dyn Future<Item=LdapWrapper, Error=io::Error>>
     {
         let handle = handle.clone();
         let hostname = hostname.to_owned();
@@ -65,7 +65,7 @@ impl LdapWrapper {
 
     #[cfg(all(unix, not(feature = "minimal")))]
     fn connect_unix(path: &str, handle: &Handle, settings: LdapConnSettings)
-        -> Box<Future<Item=LdapWrapper, Error=io::Error>>
+        -> Box<dyn Future<Item=LdapWrapper, Error=io::Error>>
     {
         let lw = Ldap::connect_unix(path, handle, settings)
             .map(|ldap| {
@@ -389,7 +389,7 @@ impl LdapConn {
 /// ```
 #[derive(Clone)]
 pub struct LdapConnAsync {
-    in_progress: Rc<RefCell<Box<Future<Item=LdapWrapper, Error=io::Error>>>>,
+    in_progress: Rc<RefCell<Box<dyn Future<Item=LdapWrapper, Error=io::Error>>>>,
     wrapper: Rc<RefCell<Option<LdapWrapper>>>,
 }
 
@@ -480,7 +480,7 @@ impl LdapConnAsync {
             Some(h) if h == "" => ("localhost", format!("localhost:{}", port)),
             _ => panic!("unexpected None from url.host_str()"),
         };
-        let addr: Box<Future<Item=SocketAddr, Error=io::Error>> = match url.host() {
+        let addr: Box<dyn Future<Item=SocketAddr, Error=io::Error>> = match url.host() {
             Some(Host::Ipv4(v4)) => Box::new(future::ok(SocketAddr::new(IpAddr::V4(v4), port))),
             Some(Host::Ipv6(v6)) => Box::new(future::ok(SocketAddr::new(IpAddr::V6(v6), port))),
             Some(Host::Domain(_)) => resolve_addr(&host_port, &settings),

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -12,7 +12,7 @@ use result::LdapResult;
 impl Ldap {
     /// See [`LdapConn::delete()`](struct.LdapConn.html#method.delete).
     pub fn delete(&self, dn: &str) ->
-            Box<Future<Item=LdapResult, Error=io::Error>> {
+            Box<dyn Future<Item=LdapResult, Error=io::Error>> {
         let req = Tag::OctetString(OctetString {
             id: 10,
             class: TagClass::Application,

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -15,7 +15,7 @@ use result::ExopResult;
 impl Ldap {
     /// See [`LdapConn::extended()`](struct.LdapConn.html#method.extended).
     pub fn extended<E>(&self, exop: E) ->
-        Box<Future<Item=ExopResult, Error=io::Error>>
+        Box<dyn Future<Item=ExopResult, Error=io::Error>>
         where E: Into<Exop>
     {
         let req = Tag::Sequence(Sequence {

--- a/src/modify.rs
+++ b/src/modify.rs
@@ -26,7 +26,7 @@ pub enum Mod<S: AsRef<[u8]> + Eq + Hash> {
 impl Ldap {
     /// See [`LdapConn::modify()`](struct.LdapConn.html#method.modify).
     pub fn modify<S: AsRef<[u8]> + Eq + Hash>(&self, dn: &str, mods: Vec<Mod<S>>) ->
-            Box<Future<Item=LdapResult, Error=io::Error>> {
+            Box<dyn Future<Item=LdapResult, Error=io::Error>> {
         let mut any_add_empty = false;
         let req = Tag::Sequence(Sequence {
             id: 6,

--- a/src/modifydn.rs
+++ b/src/modifydn.rs
@@ -12,7 +12,7 @@ use result::LdapResult;
 impl Ldap {
     /// See [`LdapConn::modifydn()`](struct.LdapConn.html#method.modifydn).
     pub fn modifydn(&self, dn: &str, rdn: &str, delete_old: bool, new_sup: Option<&str>) ->
-            Box<Future<Item=LdapResult, Error=io::Error>> {
+            Box<dyn Future<Item=LdapResult, Error=io::Error>> {
         let mut params = vec![
            Tag::OctetString(OctetString {
                inner: Vec::from(dn.as_bytes()),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -227,7 +227,7 @@ impl Decoder for LdapCodec {
 }
 
 impl Encoder for LdapCodec {
-    type Item = (RequestId, (LdapOp, Box<Fn(i32)>));
+    type Item = (RequestId, (LdapOp, Box<dyn Fn(i32)>));
     type Error = io::Error;
 
     fn encode(&mut self, msg: Self::Item, into: &mut BytesMut) -> io::Result<()> {
@@ -335,9 +335,9 @@ impl<T> Stream for ResponseFilter<T>
 }
 
 impl<T> futures::Sink for ResponseFilter<T>
-    where T: futures::Sink<SinkItem=(RequestId, (LdapOp, Box<Fn(i32)>)), SinkError=io::Error>
+    where T: futures::Sink<SinkItem=(RequestId, (LdapOp, Box<dyn Fn(i32)>)), SinkError=io::Error>
 {
-    type SinkItem = (RequestId, (LdapOp, Box<Fn(i32)>));
+    type SinkItem = (RequestId, (LdapOp, Box<dyn Fn(i32)>));
     type SinkError = io::Error;
 
     fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
@@ -350,7 +350,7 @@ impl<T> futures::Sink for ResponseFilter<T>
 }
 
 impl<T: AsyncRead + AsyncWrite + 'static> ClientProto<T> for LdapProto {
-    type Request = (LdapOp, Box<Fn(i32)>);
+    type Request = (LdapOp, Box<dyn Fn(i32)>);
     type Response = (Tag, Vec<Control>);
 
     type Transport = ResponseFilter<Framed<T, LdapCodec>>;

--- a/src/search.rs
+++ b/src/search.rs
@@ -463,7 +463,7 @@ impl SearchOptions {
 impl Ldap {
     /// See [`LdapConn::search()`](struct.LdapConn.html#method.search).
     pub fn search<S: AsRef<str>>(&self, base: &str, scope: Scope, filter: &str, attrs: Vec<S>) ->
-        Box<Future<Item=SearchResult, Error=io::Error>>
+        Box<dyn Future<Item=SearchResult, Error=io::Error>>
     {
         let srch = self
             .streaming_search(base, scope, filter, attrs)
@@ -488,7 +488,7 @@ impl Ldap {
     /// [`get_result_rx()`](struct.SearchStream.html#method.get_result_rx). The stream and
     /// the receiver should be polled concurrently with `Future::join()`.
     pub fn streaming_search<S: AsRef<str>>(&self, base: &str, scope: Scope, filter: &str, attrs: Vec<S>) ->
-        Box<Future<Item=SearchStream, Error=io::Error>>
+        Box<dyn Future<Item=SearchStream, Error=io::Error>>
     {
         let opts = match next_search_options(self) {
             Some(opts) => opts,

--- a/src/tls_client.rs
+++ b/src/tls_client.rs
@@ -56,7 +56,7 @@ impl<I> ClientProto<I> for TlsClient
     type Request = <LdapProto as ClientProto<TlsStream<I>>>::Request;
     type Response = <LdapProto as ClientProto<TlsStream<I>>>::Response;
     type Transport = <LdapProto as ClientProto<TlsStream<I>>>::Transport;
-    type BindTransport = Box<Future<Item=Self::Transport, Error=io::Error>>;
+    type BindTransport = Box<dyn Future<Item=Self::Transport, Error=io::Error>>;
 
     fn bind_transport(&self, io: I) -> Self::BindTransport {
         let hostname = self.hostname.clone();

--- a/src/unbind.rs
+++ b/src/unbind.rs
@@ -11,7 +11,7 @@ use ldap::{Ldap, LdapOp};
 impl Ldap {
     /// See [`LdapConn::unbind()`](struct.LdapConn.html#method.unbind).
     pub fn unbind(&self) ->
-            Box<Future<Item=(), Error=io::Error>> {
+            Box<dyn Future<Item=(), Error=io::Error>> {
         let req = Tag::Null(Null {
             id: 2,
             class: TagClass::Application,


### PR DESCRIPTION
This is (part of) an attempt to help bringing the `ldap3` crate more up-to-date with the rest of the rust community.

Trait objects without an explicit `dyn` are deprecated.

This patch is generated entirely by running `cargo fix`.