### PR TITLE
Use std library for byteorder.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/inejge/ldap3"
 version = "0.6.1"
 
 [dependencies]
-byteorder = "1.0.0"
 bytes = "0.4.1"
 futures = "0.1.15"
 lazy_static = "1.1"

--- a/lber/Cargo.toml
+++ b/lber/Cargo.toml
@@ -10,6 +10,5 @@ documentation = "https://docs.rs/ldap3"
 version = "0.1.6"
 
 [dependencies]
-byteorder = "1.0.0"
 bytes = "0.4.1"
 nom = "2.0.1"

--- a/lber/src/lib.rs
+++ b/lber/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate byteorder;
 extern crate bytes;
 #[macro_use]
 extern crate nom;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,6 @@
 //! ```
 
 extern crate bytes;
-extern crate byteorder;
 #[macro_use]
 extern crate futures;
 #[macro_use]


### PR DESCRIPTION
This is (part of) an attempt to help bringing the `ldap3` crate more up-to-date with the rest of the rust community.

The external `byteorder` crate is no longer needed, since std integer types provides `to_be_bytes()` and similar methods since rustc 1.32.