### PR TITLE
Rustls update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Cargo.lock
 
 # IDEA config
 /.idea/
+
+# VSCode config
+/.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ lazy_static = "1.4.0"
 thiserror = "1.0.15"
 native-tls = { version = "0.2.4", optional = true }
 tokio-native-tls = { version = "0.1.0", optional = true }
-rustls = { version = "0.17.0", optional = true }
-tokio-rustls = { version = "0.13.0", optional = true, features = ["dangerous_configuration"]}
+rustls = { version = "0.18.1", optional = true }
+tokio-rustls = { version = "0.14.0", optional = true, features = ["dangerous_configuration"]}
 maplit = "1.0.2"
 async-trait = "0.1.30"
 


### PR DESCRIPTION
Just to bump rustls to latest version to solve some dep version conflict I'm facing in my app (and added `.vscode` directory to the `.gitignore`)