### PR TITLE
Add is_closed()

### DIFF
--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -133,6 +133,11 @@ impl Ldap {
         Ok((result, exop))
     }
 
+    /// Says if the underlying connection has been closed
+    pub fn is_closed(&self) -> bool {
+        self.tx.is_closed()
+    }
+
     /// Use the provided `SearchOptions` with the next Search operation, which can
     /// be invoked directly on the result of this method. If this method is used in
     /// combination with a non-Search operation, the provided options will be silently

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -134,7 +134,7 @@ impl Ldap {
     }
 
     /// Says if the underlying connection has been closed
-    pub fn is_closed(&self) -> bool {
+    pub fn is_closed(&mut self) -> bool {
         self.tx.is_closed()
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -86,6 +86,11 @@ impl LdapConn {
         self
     }
 
+    /// Says if the underlying connection has been closed
+    pub fn is_closed(&mut self) -> bool {
+        self.ldap.tx.is_closed()
+    }
+
     /// See [`Ldap::simple_bind()`](struct.Ldap.html#method.simple_bind).
     pub fn simple_bind(&mut self, bind_dn: &str, bind_pw: &str) -> Result<LdapResult> {
         let rt = &mut self.rt;


### PR DESCRIPTION
Fixes #67
Add the `is_closed()` method to check the underlying connection state. 
 On behalf of Isode Ltd.