### PR TITLE
Take slices instead of Vec(s) to allow passing filters without cloning

### DIFF
--- a/examples/moddn_sync.rs
+++ b/examples/moddn_sync.rs
@@ -16,7 +16,7 @@ fn main() -> Result<()> {
             "ou=People,dc=example,dc=org",
             Scope::OneLevel,
             "(|(uid=test)(uid=next))",
-            vec!["uid"],
+            &["uid"],
         )?
         .success()?;
     let sr = SearchEntry::construct(rs.into_iter().next().expect("entry"));

--- a/examples/modify_relax_sync.rs
+++ b/examples/modify_relax_sync.rs
@@ -20,7 +20,7 @@ fn main() -> Result<()> {
             "uid=inejge,ou=People,dc=example,dc=org",
             Scope::Base,
             "(objectClass=account)",
-            vec!["*"],
+            &["*"],
         )?
         .success()?;
     let mod_vec = match rs.len() {

--- a/examples/search_abandon.rs
+++ b/examples/search_abandon.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
             "ou=Places,dc=example,dc=org",
             Scope::Subtree,
             "objectClass=locality",
-            vec!["l"],
+            &["l"],
         )
         .await?;
     while let Some(_r) = stream.next().await? {

--- a/examples/search_adapted.rs
+++ b/examples/search_adapted.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
             "dc=example,dc=org",
             Scope::OneLevel,
             "(objectClass=*)",
-            vec!["*"],
+            &["*"],
         )
         .await?;
     while let Some(entry) = search.next().await? {
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
             "dc=example,dc=org",
             Scope::OneLevel,
             "(objectClass=*)",
-            vec!["*"],
+            &["*"],
         )
         .await?;
     while let Some(entry) = search.next().await? {

--- a/examples/search_adapted_paged_plus.rs
+++ b/examples/search_adapted_paged_plus.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
             "dc=example,dc=org",
             Scope::Subtree,
             "(objectClass=*)",
-            vec!["dn"],
+            &["dn"],
         )
         .await?;
     while let Some(entry) = search.next().await? {

--- a/examples/search_adapted_paged_plus_sync.rs
+++ b/examples/search_adapted_paged_plus_sync.rs
@@ -19,7 +19,7 @@ fn main() -> Result<()> {
         "dc=example,dc=org",
         Scope::Subtree,
         "(objectClass=*)",
-        vec!["dn"],
+        &["dn"],
     )?;
     while let Some(entry) = search.next()? {
         let entry = SearchEntry::construct(entry);

--- a/examples/search_entrystream_sync.rs
+++ b/examples/search_entrystream_sync.rs
@@ -16,7 +16,7 @@ fn main() -> Result<()> {
         "ou=Places,dc=example,dc=org",
         Scope::Subtree,
         "(&(l=ma*)(objectClass=locality))",
-        vec!["l"],
+        &["l"],
     )?;
     while let Some(entry) = search.next()? {
         let entry = SearchEntry::construct(entry);

--- a/examples/search_starttls_noverify.rs
+++ b/examples/search_starttls_noverify.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
             "ou=Places,dc=example,dc=org",
             Scope::Subtree,
             "(&(l=ma*)(objectClass=locality))",
-            vec!["l"],
+            &["l"],
         )
         .await?;
     while let Some(entry) = search.next().await? {

--- a/examples/search_url_params_sync.rs
+++ b/examples/search_url_params_sync.rs
@@ -16,7 +16,7 @@ fn main() -> Result<()> {
             params.base.as_ref(),
             params.scope,
             params.filter.as_ref(),
-            params.attrs,
+            &params.attrs,
         )?
         .success()?;
     for entry in rs {

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -260,7 +260,7 @@ impl Ldap {
         base: &str,
         scope: Scope,
         filter: &str,
-        attrs: Vec<S>,
+        attrs: &[S],
     ) -> Result<SearchResult> {
         let mut stream = self
             .streaming_search_with(EntriesOnly::new(), base, scope, filter, attrs)
@@ -282,7 +282,7 @@ impl Ldap {
         base: &str,
         scope: Scope,
         filter: &str,
-        attrs: Vec<S>,
+        attrs: &'a [S],
     ) -> Result<SearchStream<'a, S>> {
         self.streaming_search_with(vec![], base, scope, filter, attrs)
             .await
@@ -301,7 +301,7 @@ impl Ldap {
         base: &str,
         scope: Scope,
         filter: &str,
-        attrs: Vec<S>,
+        attrs: &'a [S],
     ) -> Result<SearchStream<'a, S>> {
         let mut ldap = self.clone();
         ldap.controls = self.controls.take();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //!         "ou=Places,dc=example,dc=org",
 //!         Scope::Subtree,
 //!         "(&(objectClass=locality)(l=ma*))",
-//!         vec!["l"]
+//!         &["l"]
 //!     )?.success()?;
 //!     for entry in rs {
 //!         println!("{:?}", SearchEntry::construct(entry));
@@ -78,7 +78,7 @@
 //!         "ou=Places,dc=example,dc=org",
 //!         Scope::Subtree,
 //!         "(&(objectClass=locality)(l=ma*))",
-//!         vec!["l"]
+//!         &["l"]
 //!     ).await?.success()?;
 //!     for entry in rs {
 //!         println!("{:?}", SearchEntry::construct(entry));

--- a/src/search.rs
+++ b/src/search.rs
@@ -603,7 +603,7 @@ where
         base: &str,
         scope: Scope,
         filter: &str,
-        attrs: Vec<S>,
+        attrs: &[S],
     ) -> Result<()> {
         let opts = match self.ldap.search_opts.take() {
             Some(opts) => opts,
@@ -729,7 +729,7 @@ where
         base: &str,
         scope: Scope,
         filter: &str,
-        attrs: Vec<S>,
+        attrs: &'a [S],
     ) -> Result<()> {
         if self.state != StreamState::Fresh {
             return Ok(());

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -111,7 +111,7 @@ impl LdapConn {
         base: &str,
         scope: Scope,
         filter: &str,
-        attrs: Vec<S>,
+        attrs: &'a [S],
     ) -> Result<SearchResult> {
         let rt = &mut self.rt;
         let ldap = &mut self.ldap;
@@ -126,7 +126,7 @@ impl LdapConn {
         base: &str,
         scope: Scope,
         filter: &str,
-        attrs: Vec<S>,
+        attrs: &'a [S],
     ) -> Result<EntryStream<'a, 'b, S>> {
         let rt = &mut self.rt;
         let ldap = &mut self.ldap;
@@ -148,7 +148,7 @@ impl LdapConn {
         base: &str,
         scope: Scope,
         filter: &str,
-        attrs: Vec<S>,
+        attrs: &'a [S],
     ) -> Result<EntryStream<'a, 'b, S>> {
         let rt = &mut self.rt;
         let ldap = &mut self.ldap;


### PR DESCRIPTION
The current design makes it impossible to reusing the same attributes Vec for multiple queries (as the functions expect owned Vec).
This PR aim to fix this by making the functions take borrowed slices instead.

This is currently a **breaking change** but it should be possible to use proxy functions to keep the compatibility with the current API design (or to refactor the functions to be generic over both a Vec or a slice).