### PR TITLE
Allow getting the peer certificate as DER

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -38,6 +38,12 @@ pub(crate) type ItemSender = mpsc::UnboundedSender<(SearchItem, Vec<Control>)>;
 pub(crate) type ResultSender = oneshot::Sender<(Tag, Vec<Control>)>;
 
 #[derive(Debug)]
+pub enum MiscSender {
+    #[cfg(any(feature = "tls-native", feature = "tls-rustls"))]
+    Cert(oneshot::Sender<Option<Vec<u8>>>),
+}
+
+#[derive(Debug)]
 pub enum LdapOp {
     Single,
     Search(ItemSender),

--- a/src/result.rs
+++ b/src/result.rs
@@ -13,6 +13,7 @@ use std::result::Result as StdResult;
 use crate::controls::Control;
 use crate::exop::Exop;
 use crate::ldap::SaslCreds;
+use crate::protocol::MiscSender;
 use crate::protocol::{LdapOp, MaybeControls, ResultSender};
 use crate::search::parse_refs;
 use crate::search::ResultEntry;
@@ -68,6 +69,13 @@ pub enum LdapError {
     IdScrubSend {
         #[from]
         source: mpsc::error::SendError<RequestId>,
+    },
+
+    /// Error while sending a misc result.
+    #[error("cert send error: {source}")]
+    MiscSend {
+        #[from]
+        source: mpsc::error::SendError<MiscSender>,
     },
 
     /// Operation or connection timeout.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -257,6 +257,16 @@ impl LdapConn {
         let ldap = &mut self.ldap;
         rt.block_on(async move { ldap.abandon(msgid).await })
     }
+
+    /// Returns the TLS peer certificate in the DER format.
+    /// The method returns Ok(None) if no certificate was found or
+    /// if the connection does not use TLS.
+    #[cfg(any(feature = "tls-native", feature = "tls-rustls"))]
+    pub fn get_peer_certificate_der(&mut self) -> Result<Option<Vec<u8>>> {
+        let rt = &mut self.rt;
+        let ldap = &mut self.ldap;
+        rt.block_on(async move { ldap.get_peer_certificate_der().await })
+    }
 }
 
 /// Handle for obtaining a stream of search results.


### PR DESCRIPTION
There is only the DER format available because both libraries only support this format and returning a Vec<u8> allows us to have a library-independant way of returning the data.