### PR TITLE
Add generic SASL bind support using rsasl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ x509-parser = { version = "0.13.1", optional = true }
 ring = { version = "0.16.20", optional = true }
 cross-krb5 = { version = "0.3.0", optional = true }
 async-trait = "0.1.41"
+rsasl = { version = "2.0.0-rc.4", features = ["provider"] }
 
 [dependencies.lber]
 path = "lber"
@@ -48,6 +49,7 @@ gssapi = ["cross-krb5"]
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "io-util", "sync", "time", "net", "rt-multi-thread"] }
 env_logger = "0.9.0"
+rsasl = { version = "2.0.0-rc.4", features = ["config_builder", "scram-sha-2"] }
 
 [package.metadata.docs.rs]
 default-features = false

--- a/examples/whoami_sasl.rs
+++ b/examples/whoami_sasl.rs
@@ -1,0 +1,27 @@
+// Demonstrates:
+//
+// 1. SASL EXTERNAL bind;
+// 2. "Who Am I?" Extended operation.
+//
+// Uses the async client.
+//
+// Notice: only works on Unix (uses Unix domain sockets)
+
+use ldap3::exop::{WhoAmI, WhoAmIResp};
+use ldap3::result::Result;
+use ldap3::LdapConnAsync;
+use rsasl::prelude::SASLConfig;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let sasl =
+        SASLConfig::with_credentials(None, "testuser".to_string(), "testpassword".to_string())?;
+
+    let (conn, mut ldap) = LdapConnAsync::new("ldap://127.0.0.1/").await?;
+    ldap3::drive!(conn);
+    ldap.sasl_bind(sasl).await?;
+    let (exop, _res) = ldap.extended(WhoAmI).await?.success()?;
+    let whoami: WhoAmIResp = exop.parse();
+    println!("{}", whoami.authzid);
+    Ok(ldap.unbind().await?)
+}

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -14,13 +14,14 @@ use crate::result::{
     CompareResult, ExopResult, LdapError, LdapResult, LdapResultExt, Result, SearchResult,
 };
 use crate::search::{Scope, SearchOptions, SearchStream};
-use crate::RequestId;
+use crate::{RequestId, SearchEntry};
 
 use lber::common::TagClass;
 use lber::structures::{Boolean, Enumerated, Integer, Null, OctetString, Sequence, Set, Tag};
 
 #[cfg(feature = "gssapi")]
 use cross_krb5::{ClientCtx, InitiateFlags, K5Ctx, Step};
+use rsasl::prelude::{Mechname, SASLClient, SASLConfig};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time;
 
@@ -270,6 +271,112 @@ impl Ldap {
     pub async fn sasl_external_bind(&mut self) -> Result<LdapResult> {
         let req = sasl_bind_req("EXTERNAL", Some(b""));
         Ok(self.op_call(LdapOp::Single, req).await?.0)
+    }
+
+    pub async fn sasl_bind(&mut self, sasl: Arc<SASLConfig>) -> Result<()> {
+        const SASL_MECH_ATTR: &str = "supportedSASLMechanisms";
+        const LDAP_RESULT_OK: u32 = 0;
+        const LDAP_RESULT_SASL_BIND_IN_PROGRESS: u32 = 14;
+
+        let res = self
+            .search("", Scope::Base, "(objectClass=*)", [SASL_MECH_ATTR])
+            .await?;
+        let (mut results, _) = res.non_error()?;
+        let root_dse_res = results.pop().ok_or(LdapError::NoRootDSE)?;
+        let mut root_dse = SearchEntry::construct(root_dse_res);
+        let avail_mechanisms = root_dse
+            .attrs
+            .remove(SASL_MECH_ATTR)
+            .unwrap_or(Vec::with_capacity(0));
+
+        let mechs: Vec<&Mechname> = avail_mechanisms
+            .iter()
+            .filter_map(|raw| Mechname::parse(raw.as_bytes()).ok())
+            .collect();
+
+        let client = SASLClient::new(sasl);
+        let mut session = client.start_suggested(mechs.iter())?;
+
+        let mut last_rc = 0u32;
+        // If the selected mechanism is client-first, we set input to None and go to the main
+        // authentication loop.
+        // If the mechanism is server-first we must instead send a first bind call with no client
+        // credentials so the server can send us the initial SASL authentication token.
+        let mut input = if session.are_we_first() {
+            None
+        } else {
+            let req = sasl_bind_req(session.get_mechname(), None);
+            let ans = self.op_call(LdapOp::Single, req).await?;
+            if !matches!(
+                (ans.0).rc,
+                LDAP_RESULT_SASL_BIND_IN_PROGRESS | LDAP_RESULT_OK
+            ) {
+                return Err(LdapError::LdapResult { result: ans.0 });
+            }
+            last_rc = ans.0.rc;
+            ans.2 .0
+        };
+
+        let mut data = Vec::new();
+        // Main SASL authentication loop
+        while {
+            // Call step with the token input. On the first loop this is either the initial sasl
+            // token returned by the server, or 'None' if the selected mechanism is client-first.
+            let state = session.step(input.as_deref(), &mut data)?;
+            // On all future loops the token input is set from the server response to our bind
+            // request.
+            // There is the special case that the last call to `session.step` did not generate
+            // any output. Notably, this can only happen if state.is_running() *will also* be
+            // false, meaning this can only happen on the last loop iteration.
+            // It may be expected, for example if the last bind response by the server contained
+            // all data that the client needed to finish authentication, and no further messages
+            // are required. It may be unexpected by the server, which is handled in the `else`
+            // case.
+            input = if state.has_sent_message() {
+                let req = sasl_bind_req(session.get_mechname(), Some(&data[..]));
+                let ans = self.op_call(LdapOp::Single, req).await?;
+                // Save the rc of this
+                last_rc = ans.0.rc;
+
+                if !matches!(
+                    (ans.0).rc,
+                    LDAP_RESULT_SASL_BIND_IN_PROGRESS | LDAP_RESULT_OK
+                ) {
+                    return Err(LdapError::LdapResult { result: ans.0 });
+                }
+
+                ans.2 .0
+            } else {
+                // In the case that the client does not want to send a message but the server does
+                // expect one (as indicated by `last_rc`), we send an bind request with no
+                // credentials. A server should either treat this as authentication failure if
+                // unexpected, or return a successful bindResponse if expected.
+                if last_rc == LDAP_RESULT_SASL_BIND_IN_PROGRESS {
+                    let req = sasl_bind_req(session.get_mechname(), None);
+                    let ans = self.op_call(LdapOp::Single, req).await?;
+                    if ans.0.rc != LDAP_RESULT_OK {
+                        return Err(LdapError::LdapResult { result: ans.0 });
+                    }
+                }
+                // Explicitly set the input to `None` to make sure we do not call `session.step`
+                // with the same input data twice.
+                None
+            };
+
+            // Clear the data buffer so the next call to `step` does not append to it.
+            data.clear();
+
+            // `state.is_running()` will return `true` if our end of the selected mechanism
+            // expects further calls to `session.step()` to be made. A dishonest server could try
+            // to circumvent mutual authentication by returning a success bindResponse early or
+            // without the data required for mutual authentication, so the server rc must not be
+            // relied on here. If a malicious server does try this attack vector relying only on
+            // `state.is_running()` will result in an additional call to `session.step()` with a
+            // `None` input token, which mechanism will special case as mutual authentication
+            // failure if it happens at that stage.
+            state.is_running()
+        } {}
+        Ok(())
     }
 
     #[cfg_attr(docsrs, doc(cfg(feature = "gssapi")))]

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,6 +5,7 @@
 //! helper methods, which adapt LDAP result and error handling to be a closer
 //! match to Rust conventions.
 
+use rsasl::prelude::{SASLError, SessionError};
 use std::error::Error;
 use std::fmt;
 use std::io;
@@ -163,6 +164,22 @@ pub enum LdapError {
     /// No token received from GSSAPI acceptor.
     #[error("no token received from acceptor")]
     NoGssapiToken,
+
+    #[error("Setting up SASL authentication failed")]
+    SaslError(
+        #[from]
+        #[source]
+        SASLError,
+    ),
+    #[error("SASL session operation failed")]
+    SaslSessionError(
+        #[from]
+        #[source]
+        SessionError,
+    ),
+
+    #[error("LDAP server did not return a root DSE")]
+    NoRootDSE,
 }
 
 impl From<LdapError> for io::Error {


### PR DESCRIPTION
Tag, you're it!

Anyway, I kinda sorta need the ability to do SASL bind for unrelated related reasons. So, based on the famous (and always wrongly attributed to Mahatma Gandhi) quote "be the change you wish to see — Arleen Lorrance", here you go! :P

The main advantage of using rsasl here is that we get separation of concern; the ldap side of things does not have to change in any way to allow for any and all SASL mechanisms to be used. In fact it won't even have to change to support mechanisms that haven't even been invented yet, as rsasl makes those entirely abstracted modular plugins that neither of us needs to care about. ¯\\\_(ツ)\_/¯

This separation also extends to selection of mechanisms, getting required information from the user for them, and all of that jazz, the `Arc<SASLConfig>` (which is wrapped in an `Arc` because it's just a fancy trait object, in other words unsized) is a freshly-fashioned configuration object provided by the downstream user that lets said user configure all the mechanism selection, preferences and all the authentication data required for the authentication.

I mean, I did write rsasl so we don't get to use other people's work here, but still, separation of concerns is good, and modular software doubly so.

Anyway, rsasl makes *heavy* use of feature unification to remove as much code as possible when it's not used, so in this configuration with only "provider" selected rsasl is *tiny*. This is useful as especially with channel binding and security layers rsasl will need to be pretty deeply integrated into the remaining code, making conditional compilation really painful really fast. That being said, if you prefer it as an optional dependency we can do that too.

Lastly:

Compared to the existing GSS-API bind this PR doesn't implement security layers because … well mostly because I haven't decided how I want to handle security layers on the rsasl side yet. They do kinda stink and I'd love to just … *not*, but I fear that won't be a good option either.

Also this MR does not yet do channel binding. I've been meaning to write some utilities to extract the required channel binding data from rustls and native-tls but I've been dreading it and haven't yet gotten around to it. (I really should though <.<)