### PR TITLE
Update rustls version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ lazy_static = "1.4.0"
 thiserror = "1.0.38"
 native-tls = { version = "0.2.11", optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
-rustls = { version = "0.21.0", optional = true }
-tokio-rustls = { version = "0.24.0", optional = true, features = ["dangerous_configuration"] }
-rustls-native-certs = { version = "0.6.2", optional = true }
+rustls = { version = "0.22.0", optional = true }
+tokio-rustls = { version = "0.25.0", optional = true }
+rustls-native-certs = { version = "0.7.0", optional = true }
 x509-parser = { version = "0.15.0", optional = true }
 ring = { version = "0.16.20", optional = true }
 cross-krb5 = { version = "0.3.0", optional = true }


### PR DESCRIPTION
Closes #117.

I removed the `dangerous_configuration` feature from `tokio-rustls` because it is now available by default, see release notes: https://github.com/rustls/rustls/releases/tag/v%2F0.22.0.