### PR TITLE
Correct doc for UnrecognizedCriticalExtension

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -150,8 +150,8 @@ pub enum LdapError {
     #[error("invalid scope string in LDAP URL: {0}")]
     InvalidScopeString(String),
 
-    /// Unreconized LDAP URL extension marked as critical.
-    #[error("unrecognized critical LDAP URL extension: {0}")]
+    /// Unrecognized LDAP control that was marked as "critical".
+    #[error("unrecognized critical LDAP control: {0}")]
     UnrecognizedCriticalExtension(String),
 
     #[cfg(feature = "gssapi")]


### PR DESCRIPTION
Let me know if you'd like me to open an issue first.

There's a spelling mistake in the existing doc. But the main error is that `UnrecognizedCriticalExtension` is nothing to do with URLs, it is to do with controls.