### PR TITLE
feat: introduce serde feature for `Result` types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ x509-parser = { version = "0.15.0", optional = true }
 ring = { version = "0.17.7", optional = true }
 cross-krb5 = { version = "0.3.0", optional = true }
 async-trait = "0.1.60"
+serde = { version = "1.0.198", features = ["derive"], optional = true }
 
 [dependencies.lber]
 path = "lber"
@@ -44,6 +45,7 @@ tls-native = ["native-tls", "tokio-native-tls", "tokio/rt"]
 tls-rustls = ["rustls", "tokio-rustls", "rustls-native-certs", "x509-parser", "ring", "tokio/rt"]
 sync = ["tokio/rt"]
 gssapi = ["cross-krb5"]
+serde = ["dep:serde", "lber/serde"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "io-util", "sync", "time", "net", "rt-multi-thread"] }

--- a/lber/Cargo.toml
+++ b/lber/Cargo.toml
@@ -12,3 +12,7 @@ version = "0.4.2"
 [dependencies]
 bytes = "1.3.0"
 nom = "7.1.1"
+serde = { version = "1.0.198", features = ["derive"], optional = true }
+
+[features]
+serde = ["dep:serde"]

--- a/lber/src/common.rs
+++ b/lber/src/common.rs
@@ -23,6 +23,19 @@ pub enum TagClass {
     Private = 3,
 }
 
+#[cfg(feature = "serde")]
+extern crate serde;
+
+#[cfg(feature = "serde")]
+impl self::serde::Serialize for TagClass {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: self::serde::Serializer,
+    {
+        serializer.serialize_u8(*self as u8)
+    }
+}
+
 impl TagClass {
     pub fn from_u8(n: u8) -> Option<TagClass> {
         match n {

--- a/src/exop_impl.rs
+++ b/src/exop_impl.rs
@@ -1,6 +1,9 @@
 use lber::common::TagClass;
 use lber::structures::{OctetString, Tag};
 
+#[cfg(feature = "serde")]
+use serde::Serialize;
+
 mod whoami;
 pub use self::whoami::{WhoAmI, WhoAmIResp};
 
@@ -21,6 +24,20 @@ pub struct Exop {
     pub name: Option<String>,
     /// Request or response value. It may be absent in both cases.
     pub val: Option<Vec<u8>>,
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Exop {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut seq = serializer.serialize_struct("Exop", 2)?;
+        seq.serialize_field("name", &self.name)?;
+        seq.serialize_field("val", &self.val)?;
+        seq.end()
+    }
 }
 
 impl Exop {

--- a/src/exop_impl.rs
+++ b/src/exop_impl.rs
@@ -2,7 +2,7 @@ use lber::common::TagClass;
 use lber::structures::{OctetString, Tag};
 
 #[cfg(feature = "serde")]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 mod whoami;
 pub use self::whoami::{WhoAmI, WhoAmIResp};
@@ -37,6 +37,58 @@ impl Serialize for Exop {
         seq.serialize_field("name", &self.name)?;
         seq.serialize_field("val", &self.val)?;
         seq.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Exop {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+        use serde::de::MapAccess;
+        use serde::de::Visitor;
+        use std::fmt;
+
+        struct ExopVisitor;
+        impl<'de> Visitor<'de> for ExopVisitor {
+            type Value = Exop;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a struct with `name` and `val` fields")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut name = None;
+                let mut val = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        "name" => {
+                            if name.is_some() {
+                                return Err(A::Error::duplicate_field("name"));
+                            }
+                            name = Some(map.next_value()?);
+                        }
+                        "val" => {
+                            if val.is_some() {
+                                return Err(A::Error::duplicate_field("val"));
+                            }
+                            val = Some(map.next_value()?);
+                        }
+                        _ => {
+                            return Err(A::Error::unknown_field(key, &["name", "val"]));
+                        }
+                    }
+                }
+                Ok(Exop { name, val })
+            }
+        }
+
+        deserializer.deserialize_struct("Exop", &["name", "val"], ExopVisitor)
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -17,6 +17,9 @@ use lber::common::TagClass;
 use lber::structure::StructureTag;
 use lber::structures::{Boolean, Enumerated, Integer, OctetString, Sequence, Tag};
 
+#[cfg(feature = "serde")]
+use serde::Serialize;
+
 /// Possible values for search scope.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Scope {
@@ -73,6 +76,19 @@ impl ResultEntry {
     /// Returns true if the enclosed entry is an intermediate message.
     pub fn is_intermediate(&self) -> bool {
         self.0.id == 25
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for ResultEntry {fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut seq = serializer.serialize_struct("ResultEntry", 2)?;
+        seq.serialize_field("entry", &self.0)?;
+        seq.serialize_field("controls", &self.1)?;
+        seq.end()
     }
 }
 


### PR DESCRIPTION
Serde (Serialize) would be a fantastic feature for ldap3.  

Implemented Seralize for `Result` types.