### PR TITLE
Add support for creating LDAP clients from existing TcpStream/UnixStream.

### DIFF
--- a/examples/bind_sync.rs
+++ b/examples/bind_sync.rs
@@ -1,5 +1,5 @@
 // Demonstrates synchronously connecting, binding to,
-// and disconnectiong from the server.
+// and disconnection from the server.
 
 use ldap3::result::Result;
 use ldap3::LdapConn;

--- a/examples/bind_sync_from_exiting_tcp_stream.rs
+++ b/examples/bind_sync_from_exiting_tcp_stream.rs
@@ -1,0 +1,20 @@
+// Demonstrates synchronously connecting, binding to,
+// and disconnection from the exiting tcp stream.
+
+use ldap3::result::Result;
+use ldap3::{LdapConn, LdapConnSettings};
+use std::net::TcpStream;
+use url::Url;
+
+fn main() -> Result<()> {
+    let stream = TcpStream::connect("localhost:2389")?;
+
+    // ... go into capsicum/seccomp mode, so process is not able to open new file descriptors ...
+
+    let url = Url::parse("ldap://localhost:2389").unwrap();
+    let mut ldap = LdapConn::from_tcp_stream(stream, LdapConnSettings::new(), &url)?;
+    let _res = ldap
+        .simple_bind("cn=Manager,dc=example,dc=org", "secret")?
+        .success()?;
+    Ok(ldap.unbind()?)
+}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,5 +1,8 @@
 use std::collections::HashSet;
 use std::hash::Hash;
+use std::net::TcpStream;
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
 use crate::adapters::IntoAdapterVec;
@@ -60,6 +63,53 @@ impl LdapConn {
             .build()?;
         let ldap = rt.block_on(async move {
             let (conn, ldap) = match LdapConnAsync::from_url_with_settings(settings, url).await {
+                Ok((conn, ldap)) => (conn, ldap),
+                Err(e) => return Err(e),
+            };
+            super::drive!(conn);
+            Ok(ldap)
+        })?;
+        Ok(LdapConn { ldap, rt })
+    }
+
+    /// Create a connection to an LDAP server from existing UnixStream.
+    #[cfg(unix)]
+    pub fn from_unix_stream(stream: UnixStream) -> Result<Self> {
+        let stream = tokio::net::UnixStream::from_std(stream)?;
+        let rt = runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        let ldap = rt.block_on(async move {
+            let (conn, ldap) = LdapConnAsync::from_unix_stream(stream);
+            super::drive!(conn);
+            ldap
+        });
+        Ok(LdapConn { ldap, rt })
+    }
+
+    /// Create a connection to an LDAP server from existing UnixStream.
+    #[cfg(not(unix))]
+    pub fn from_unix_stream(stream: UnixStream) -> Result<Self> {
+        unimplemented!("no Unix domain sockets on non-Unix platforms");
+    }
+
+    /// Create a connection to an LDAP server from existing TcpStream,
+    /// specified by an already parsed `Url`, using
+    /// `settings` to specify additional parameters.
+    pub fn from_tcp_stream(
+        stream: TcpStream,
+        settings: LdapConnSettings,
+        url: &Url,
+    ) -> Result<Self> {
+        let rt = runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        let ldap = rt.block_on(async move {
+            stream.set_nonblocking(true)?;
+            let stream = tokio::net::TcpStream::from_std(stream)?;
+            let (conn, ldap) = match LdapConnAsync::from_tcp_stream(stream, settings, url).await {
                 Ok((conn, ldap)) => (conn, ldap),
                 Err(e) => return Err(e),
             };


### PR DESCRIPTION
Allow creating Ldap client (sync and async) from exiting Tcp/Unix streams.

That's allows to create LDAP client from file descriptor and handle connection (with ssl) in sandboxed process.

Example scenario:
 1. Open tcp stream to LDAP server in normal mode.
 2. Go process into capsicum/seccomp mode.
 3. Handle ldap client (and SSL) in sandboxed process.
