### PR TITLE
Additonal derives for `SearchEntry`

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -130,7 +130,7 @@ impl SearchOptions {
 /// possible that a particular set of values for a binary attribute _could_ be
 /// converted into UTF-8 `String`s, the presence of such an attribute in the result
 /// entry should be checked for both in `attrs` and `bin_atrrs`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SearchEntry {
     /// Entry DN.
     pub dn: String,


### PR DESCRIPTION
For testing, having more derives for the `SearchEntry` are handy.
Concretely, having `Eq` derived might be helpfull.