### PR TITLE
Transaction extended operation support

### DIFF
--- a/examples/txn_sync.rs
+++ b/examples/txn_sync.rs
@@ -1,0 +1,50 @@
+// Demonstrates:
+//
+// 1. Simple Bind;
+// 2. "Transaction" Extended operation.
+//
+// Uses the synchronous client.
+//
+// Notice: only works on Unix (uses Unix domain sockets)
+
+use std::collections::HashSet;
+
+use ldap3::controls::TxnSpec;
+use ldap3::exop::{EndTxn, EndTxnResp, StartTxn, StartTxnResp};
+use ldap3::result::Result;
+use ldap3::LdapConn;
+
+fn main() -> Result<()> {
+    let mut ldap = LdapConn::new("ldap://localhost:2389")?;
+    ldap.simple_bind("cn=Manager,dc=example,dc=org", "secret")?
+        .success()?;
+    let (expo, _res) = ldap.extended(StartTxn)?.success()?;
+    let start_txn = expo.parse::<StartTxnResp>();
+
+    ldap.with_controls(TxnSpec {
+        txn_id: &start_txn.txn_id,
+    })
+    .add(
+        "uid=extra,ou=People,dc=example,dc=org",
+        vec![
+            ("objectClass", HashSet::from(["inetOrgPerson"])),
+            ("uid", HashSet::from(["extra"])),
+            ("cn", HashSet::from(["Extra User"])),
+            ("sn", HashSet::from(["User"])),
+        ],
+    )?
+    .success()?;
+
+    let (expo, _res) = ldap
+        .extended(EndTxn {
+            txn_id: &start_txn.txn_id,
+            commit: true,
+        })?
+        .success()?;
+
+    if expo.val.is_some() {
+        let end_txn = expo.parse::<EndTxnResp>();
+        println!("{:?}", end_txn);
+    }
+    Ok(ldap.unbind()?)
+}

--- a/src/controls_impl.rs
+++ b/src/controls_impl.rs
@@ -48,6 +48,9 @@ pub use self::manage_dsa_it::ManageDsaIt;
 mod matched_values;
 pub use self::matched_values::MatchedValues;
 
+mod txn;
+pub use self::txn::TxnSpec;
+
 #[rustfmt::skip]
 lazy_static! {
     static ref CONTROLS: HashMap<&'static str, ControlType> = {

--- a/src/controls_impl/txn.rs
+++ b/src/controls_impl/txn.rs
@@ -1,0 +1,21 @@
+use crate::controls::{MakeCritical, RawControl};
+
+pub const TXN_REQUEST_OID: &str = "1.3.6.1.1.21.2";
+
+/// Transaction Specification control ([RFC 5805](https://tools.ietf.org/html/rfc5805)).
+#[derive(Clone, Debug, Default)]
+pub struct TxnSpec<'a> {
+    pub txn_id: &'a str,
+}
+
+impl<'a> MakeCritical for TxnSpec<'a> {}
+
+impl<'a> From<TxnSpec<'a>> for RawControl {
+    fn from(txn: TxnSpec) -> RawControl {
+        RawControl {
+            ctype: TXN_REQUEST_OID.to_owned(),
+            crit: true,
+            val: Some(Vec::from(txn.txn_id)),
+        }
+    }
+}

--- a/src/controls_impl/txn.rs
+++ b/src/controls_impl/txn.rs
@@ -1,14 +1,15 @@
-use crate::controls::{MakeCritical, RawControl};
+use crate::controls::RawControl;
 
 pub const TXN_REQUEST_OID: &str = "1.3.6.1.1.21.2";
 
 /// Transaction Specification control ([RFC 5805](https://tools.ietf.org/html/rfc5805)).
+///
+/// This control only has the request part, and must be marked as critical.
+/// For that reason, it doesn't implement `MakeCritical`.
 #[derive(Clone, Debug, Default)]
 pub struct TxnSpec<'a> {
     pub txn_id: &'a str,
 }
-
-impl<'a> MakeCritical for TxnSpec<'a> {}
 
 impl<'a> From<TxnSpec<'a>> for RawControl {
     fn from(txn: TxnSpec) -> RawControl {

--- a/src/exop_impl.rs
+++ b/src/exop_impl.rs
@@ -10,6 +10,9 @@ pub use self::starttls::StartTLS;
 mod passmod;
 pub use self::passmod::{PasswordModify, PasswordModifyResp};
 
+mod txn;
+pub use self::txn::{StartTxn, StartTxnResp, EndTxn, EndTxnResp};
+
 /// Generic extended operation.
 ///
 /// Since the same struct can be used both for requests and responses,

--- a/src/exop_impl/txn.rs
+++ b/src/exop_impl/txn.rs
@@ -1,0 +1,172 @@
+use bytes::BytesMut;
+use lber::{
+    common::TagClass,
+    parse::{parse_tag, parse_uint},
+    structure::{StructureTag, PL},
+    structures::{ASNTag, Boolean, Sequence, Tag},
+    universal::Types,
+    write,
+};
+use std::str;
+
+use crate::{controls::Control, controls_impl::parse_controls};
+
+use super::{Exop, ExopParser};
+
+pub const TXN_START_OID: &str = "1.3.6.1.1.21.1";
+pub const TXN_END_OID: &str = "1.3.6.1.1.21.3";
+
+/// Transaction extended operation ([RFC 5805](https://tools.ietf.org/html/rfc5805)).
+///
+/// This operation doesn't have any data associated with a request. It can be combined
+/// with request controls, and if those controls change the authorization status
+/// of the request, it will be reflected in the response.
+#[derive(Clone, Debug)]
+pub struct StartTxn;
+
+/// Start Transaction response.
+///
+/// If the server has started a transaction successfully, an identifier of the transaction
+/// will be provided in the response.
+#[derive(Clone, Debug)]
+pub struct StartTxnResp {
+    pub txn_id: String,
+}
+
+impl From<StartTxn> for Exop {
+    fn from(_: StartTxn) -> Exop {
+        Exop {
+            name: Some(TXN_START_OID.to_owned()),
+            val: None,
+        }
+    }
+}
+
+impl ExopParser for StartTxnResp {
+    fn parse(val: &[u8]) -> StartTxnResp {
+        StartTxnResp {
+            txn_id: str::from_utf8(val).expect("txn_id").to_owned(),
+        }
+    }
+}
+
+/// This structure contains elements of a Transaction End request. The precise semantics
+/// of having a particular field present or absent will depend on the server receiving
+/// the request; consult the server documentation. Some rules are prescribed by the RFC
+/// and should generally apply:
+///
+/// * The `txn_id` field contains the identifier of the transaction provided in the Start
+///   Transaction response.
+///
+/// * The `commit` field indicates whether to commit or abort the transaction specified
+///   by the `txn_id`.
+#[derive(Clone, Debug)]
+pub struct EndTxn<'a> {
+    pub txn_id: &'a str,
+    pub commit: bool,
+}
+
+/// End Transaction response.
+///
+/// * If the server fails to end the transaction, it must send the `msg_id`, which is the
+///   message id of the update request.
+///
+/// * If there are no update response controls to return, the server won't send `upds_ctrls`
+///   in the response.
+#[derive(Clone, Debug)]
+pub struct EndTxnResp {
+    pub msg_id: Option<i32>,
+    pub upds_ctrls: Option<Vec<(i32, Vec<Control>)>>,
+}
+
+impl<'a> From<EndTxn<'a>> for Exop {
+    fn from(et: EndTxn) -> Exop {
+        let mut et_vec = vec![];
+        if !et.commit {
+            et_vec.push(Tag::Boolean(Boolean {
+                inner: false,
+                ..Default::default()
+            }));
+        }
+
+        et_vec.push(Tag::OctetString(lber::structures::OctetString {
+            inner: Vec::from(et.txn_id.as_bytes()),
+            ..Default::default()
+        }));
+
+        let et_val = Tag::Sequence(Sequence {
+            inner: et_vec,
+            ..Default::default()
+        })
+        .into_structure();
+        let mut buf = BytesMut::new();
+        write::encode_into(&mut buf, et_val).expect("encoded");
+
+        Exop {
+            name: Some(TXN_END_OID.to_owned()),
+            val: Some(Vec::from(&buf[..])),
+        }
+    }
+}
+
+impl ExopParser for EndTxnResp {
+    fn parse(val: &[u8]) -> EndTxnResp {
+        let mut tags = match parse_tag(val) {
+            Ok((_, tag)) => tag,
+            _ => panic!("endtxnresp: failed to parse tag"),
+        }
+        .expect_constructed()
+        .expect("endtxnresp: elements")
+        .into_iter();
+
+        let mut msg_id = None;
+        let mut upds_ctrls = None;
+        while let Some(tag) = tags.next() {
+            match tag {
+                StructureTag {
+                    id,
+                    class,
+                    payload: PL::P(v),
+                } if id == Types::Integer as u64 && class == TagClass::Universal => {
+                    msg_id = Some(match parse_uint(v.as_slice()) {
+                        Ok((_, size)) => size as i32,
+                        _ => panic!("failed to parse msg_id"),
+                    });
+                }
+                StructureTag {
+                    id,
+                    class,
+                    payload: PL::C(mut tags),
+                } if id == Types::Sequence as u64 && class == TagClass::Universal => {
+                    let mut ctrls = Vec::with_capacity(tags.len() / 2);
+                    while !tags.is_empty() {
+                        let controls = parse_controls(tags.pop().expect("element"));
+                        let msg_id = match parse_uint(
+                            tags.pop()
+                                .expect("element")
+                                .match_class(TagClass::Universal)
+                                .and_then(|t| t.match_id(Types::Integer as u64))
+                                .and_then(|t| t.expect_primitive())
+                                .expect("message id")
+                                .as_slice(),
+                        ) {
+                            Ok((_, id)) => id as i32,
+                            _ => panic!("failed to parse msg_id"),
+                        };
+                        ctrls.push((msg_id, controls));
+                    }
+                    upds_ctrls = Some(ctrls);
+
+                    break;
+                }
+                _ => panic!("failed to parse endtxnresp"),
+            }
+        }
+
+        if tags.next().is_some() {
+            panic!("failed to parse endtxnresp");
+        }
+
+        EndTxnResp { msg_id, upds_ctrls }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ pub mod controls {
     pub use crate::controls_impl::{
         EntryState, RefreshMode, SyncDone, SyncInfo, SyncRequest, SyncState,
     };
+    pub use crate::controls_impl::TxnSpec;
     pub use crate::controls_impl::{PostRead, PostReadResp, PreRead, PreReadResp, ReadEntryResp};
 }
 mod controls_impl;
@@ -216,7 +217,7 @@ pub mod exop {
     //! A response struct must implement the [`ExopParser`](trait.ExopParser.html)
     //! trait.
     pub use crate::exop_impl::{
-        Exop, ExopParser, PasswordModify, PasswordModifyResp, WhoAmI, WhoAmIResp,
+        Exop, ExopParser, PasswordModify, PasswordModifyResp, WhoAmI, WhoAmIResp, StartTxn, StartTxnResp, EndTxn, EndTxnResp,
     };
 }
 mod filter;


### PR DESCRIPTION
Implement the `Transaction` extended operation defined by [RFC 5805](https://tools.ietf.org/html/rfc5805). The change of the commit contains three parts:
- `control_impl`
  - `TxnSpec`: the request control structure of `Transaction` extended operation.
- `exop_impl`
  - `StartTxn`: the request structure of `Start Transaction`.
  - `StartTxnResp`: the response structure of `Start Transaction`.
  - `EndTxn`: the request structure of `End Transaction`.
  - `EndTxnResp`: the response structure of `ENd Transaction`.
- `examples`
  - `txn_sync`: demonstrates how to use `Transaction` extended operation.
 
Signed-off-by: Zongrun Huang <1181591811hzr@gmail.com>