### PR TITLE
Add support for using libgssapi instead of cross-krb5.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rustls-native-certs = { version = "0.8.0", optional = true }
 x509-parser = { version = "0.16.0", optional = true }
 ring = { version = "0.17.8", optional = true }
 cross-krb5 = { version = "0.4.1", optional = true }
+libgssapi = { version = "0.8.3", optional = true}
 sspi = { version = "0.14.2", optional = true }
 async-trait = "0.1.83"
 
@@ -51,6 +52,7 @@ tls-native = ["dep:native-tls", "dep:tokio-native-tls", "tokio/rt"]
 tls-rustls = ["dep:rustls", "dep:tokio-rustls", "dep:rustls-native-certs", "dep:x509-parser", "dep:ring", "tokio/rt"]
 sync = ["tokio/rt"]
 gssapi = ["cross-krb5"]
+gssapi_unix = ["libgssapi"]
 ntlm = ["sspi","dep:ring"]
 
 [dev-dependencies]

--- a/examples/whoami_gssapi_unix.rs
+++ b/examples/whoami_gssapi_unix.rs
@@ -1,0 +1,31 @@
+// Demonstrates:
+//
+// 1. SASL EXTERNAL bind;
+// 2. "Who Am I?" Extended operation.
+//
+// Uses the synchronous client with the gssapi_unix feature.
+//
+// Notice: only works on Unix (uses libgssapi instead of cross_krb5)
+
+use libgssapi::context::CtxFlags;
+use libgssapi::credential::{Cred, CredUsage};
+use libgssapi::name::Name;
+use ldap3::exop::{WhoAmI, WhoAmIResp};
+use ldap3::result::Result;
+use ldap3::LdapConn;
+
+fn main() -> Result<()> {
+    let mut ldap = LdapConn::new("ldaps://localhost")?;
+    let name = Name::new("ldap/localhost".as_bytes(), None)
+        .expect("Failed to create name");
+    let cred = Cred::acquire(None, None, CredUsage::Initiate, None)
+        .expect("Failed to acquire cred");
+    
+    let _res = ldap
+        .sasl_gssapi_bind(Some(cred), name, CtxFlags::all(), None)?
+        .success()?;
+    let exop = ldap.extended(WhoAmI)?;
+    let whoami: WhoAmIResp = exop.0.parse();
+    println!("{}", whoami.authzid);
+    Ok(ldap.unbind()?)
+}

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -381,8 +381,8 @@ impl Ldap {
 
     #[cfg_attr(docsrs, doc(cfg(feature = "gssapi_unix")))]
     #[cfg(feature = "gssapi_unix")]
-    /// Do an SASL GSSAPI bind on the connection, using the default Kerberos credentials
-    /// for the current user and `server_fqdn` for the LDAP server SPN. If the connection
+    /// Do an SASL GSSAPI bind on the connection, using the passed Kerberos credentials
+    /// for the user to bind to and `server_name` for the LDAP server `Name`. If the connection
     /// is in the clear, request and install the Kerberos confidentiality protection
     /// (i.e., encryption) security layer. If the connection is already encrypted with TLS,
     /// use Kerberos just for authentication and proceed with no security layer.

--- a/src/result.rs
+++ b/src/result.rs
@@ -158,12 +158,12 @@ pub enum LdapError {
     #[error("unrecognized critical LDAP URL extension: {0}")]
     UnrecognizedCriticalExtension(String),
 
-    #[cfg(feature = "gssapi")]
+    #[cfg(any(feature = "gssapi", feature = "gssapi_unix"))]
     /// GSSAPI operation error.
     #[error("GSSAPI operation error: {0}")]
     GssapiOperationError(String),
 
-    #[cfg(feature = "gssapi")]
+    #[cfg(any(feature = "gssapi", feature = "gssapi_unix"))]
     /// No token received from GSSAPI acceptor.
     #[error("no token received from acceptor")]
     NoGssapiToken,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::time::Duration;
-
+#[cfg(feature = "gssapi_unix")]
+use libgssapi::{credential::Cred, context::CtxFlags, name::Name, oid::Oid};
 use crate::adapters::IntoAdapterVec;
 use crate::conn::{LdapConnAsync, LdapConnSettings};
 use crate::controls_impl::IntoRawControlVec;
@@ -108,6 +109,15 @@ impl LdapConn {
         let rt = &mut self.rt;
         let ldap = &mut self.ldap;
         rt.block_on(async move { ldap.sasl_gssapi_bind(server_fqdn).await })
+    }
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "gssapi_unix")))]
+    #[cfg(feature = "gssapi_unix")]
+    /// See [`Ldap::sasl_gssapi_bind()`](struct.Ldap.html#method.sasl_gssapi_bind).
+    pub fn sasl_gssapi_bind(&mut self, cred: Option<Cred>, server_name: Name, ctx_flags: CtxFlags, mech: Option<&'static Oid>) -> Result<LdapResult> {
+        let rt = &mut self.rt;
+        let ldap = &mut self.ldap;
+        rt.block_on(async move { ldap.sasl_gssapi_bind(cred, server_name, ctx_flags, mech).await })
     }
 
     #[cfg_attr(docsrs, doc(cfg(feature = "ntlm")))]


### PR DESCRIPTION
This pull request adds the option to use [libgssapi](https://github.com/estokes/libgssapi) instead of [cross-krb5](https://github.com/estokes/cross-krb5/). This allows developers to manually pass names and credentials to ldap3 to be used, which in my usecase can be used for credential delegation.

