### PR TITLE
Add support for cross_krb5 acquired credentials

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tokio-rustls = { version = "0.26.0", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }
 x509-parser = { version = "0.16.0", optional = true }
 ring = { version = "0.17.8", optional = true }
-cross-krb5 = { version = "0.4.1", optional = true }
+cross-krb5 = { version = "0.4.2", optional = true }
 sspi = { version = "0.14.2", optional = true }
 async-trait = "0.1.83"
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::time::Duration;
-
+#[cfg(feature = "gssapi")]
+use cross_krb5::Cred;
 use crate::adapters::IntoAdapterVec;
 use crate::conn::{LdapConnAsync, LdapConnSettings};
 use crate::controls_impl::IntoRawControlVec;
@@ -110,6 +111,15 @@ impl LdapConn {
         rt.block_on(async move { ldap.sasl_gssapi_bind(server_fqdn).await })
     }
 
+    #[cfg_attr(docsrs, doc(cfg(feature = "gssapi")))]
+    #[cfg(feature = "gssapi")]
+    /// See [`Ldap::sasl_gssapi_bind()`](struct.Ldap.html#method.sasl_gssapi_bind).
+    pub fn sasl_gssapi_cred_bind(&mut self, cred: Cred, server_fqdn: &str) -> Result<LdapResult> {
+        let rt = &mut self.rt;
+        let ldap = &mut self.ldap;
+        rt.block_on(async move { ldap.sasl_gssapi_cred_bind(cred, server_fqdn).await })
+    }
+    
     #[cfg_attr(docsrs, doc(cfg(feature = "ntlm")))]
     #[cfg(feature = "ntlm")]
     /// See [`Ldap::sasl_ntlm_bind()`](struct.Ldap.html#method.sasl_ntlm_bind).


### PR DESCRIPTION
This PR adds the option to use credentials acquired in cross_krb5 through other means, which was introduced in cross_krb5 version 0.4.2. See https://github.com/estokes/cross-krb5/pull/13

Replaces #147 