### PR TITLE
Fix overlapping match arms in new_tcp

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -494,8 +494,8 @@ impl LdapConnAsync {
             port = url_port;
         }
         let (_hostname, host_port) = match url.host_str() {
-            Some(h) if !h.is_empty() => (h, format!("{}:{}", h, port)),
-            Some(h) if !h.is_empty() => ("localhost", format!("localhost:{}", port)),
+            Some("") => ("localhost", format!("localhost:{}", port)),
+            Some(h) => (h, format!("{}:{}", h, port)),
             _ => panic!("unexpected None from url.host_str()"),
         };
         let stream = match settings.std_stream {


### PR DESCRIPTION
c6fff2fe37ae004f3860e08432a9dc886319e6fa changed the first two arms of this match expression to appease clippy, but made the two guard expressions the same, `!h.is_empty()`, whereas the second arm should have the guard expression negated: `h.is_empty()`. However, if I make that change, clippy complains about a "redundant guard" and suggests I just make the pattern in that arm `Some("")`. Once I do that, it seems natural to put the arm with the more specific pattern first and drop the guard from the more general arm as well.