### PR TITLE
refactor: use ring backend for rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ lazy_static = "1.4.0"
 thiserror = "1.0.65"
 native-tls = { version = "0.2.11", optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
-rustls = { version = "0.23.16", optional = true }
-tokio-rustls = { version = "0.26.0", optional = true }
+rustls = { version = "0.23.16", optional = true, default-features = false, features = ["ring", "logging", "std", "tls12"] }
+tokio-rustls = { version = "0.26.0", optional = true, default-features = false, features = ["logging", "tls12", "ring"] }
 rustls-native-certs = { version = "0.8.0", optional = true }
 x509-parser = { version = "0.16.0", optional = true }
 ring = { version = "0.17.8", optional = true }


### PR DESCRIPTION
Clearly we prefer ring as crypto backend. This patch updates rustls to use ring, to avoid pulling in aws-lc-rs.