### PR TITLE
feature: nt hash authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ x509-parser = { version = "0.18.0", optional = true }
 ring = { version = "0.17.14", optional = true }
 cross-krb5 = { version = "0.4.2", optional = true }
 either = { version = "1.15.0", optional = true }
-sspi = { version = "0.16.1", optional = true }
+sspi = { git = "https://github.com/Devolutions/sspi-rs", rev = "dbdcde95359fafefe8241f36311bb43731221a6b", optional = true }
 async-trait = "0.1.89"
 
 [dependencies.lber]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ x509-parser = { version = "0.18.0", optional = true }
 ring = { version = "0.17.14", optional = true }
 cross-krb5 = { version = "0.4.2", optional = true }
 either = { version = "1.15.0", optional = true }
-sspi = { git = "https://github.com/Devolutions/sspi-rs", rev = "dbdcde95359fafefe8241f36311bb43731221a6b", optional = true }
+sspi = { version = "0.18.8", optional = true }
 async-trait = "0.1.89"
 
 [dependencies.lber]

--- a/examples/bind_sync_nthash.rs
+++ b/examples/bind_sync_nthash.rs
@@ -1,0 +1,66 @@
+use ldap3::{LdapConn, result::Result};
+
+fn domain_to_base(domain: &str) -> String {
+    domain
+        .split('.')
+        .map(|part| format!("dc={part}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn main() -> Result<()> {
+    #[cfg(not(feature = "ntlm"))]
+    {
+        println!("This example requires the 'ntlm' feature to be enabled. Add `--features ntlm`.");
+        return Ok(());
+    }
+
+    env_logger::Builder::from_default_env()
+        .filter_level(log::LevelFilter::Debug)
+        .init();
+
+    let args = std::env::args().collect::<Vec<_>>();
+    if args.len() != 5 {
+        eprintln!("Usage: {} <host> <username> <domain> <ntlm_hash>", args[0]);
+        return Ok(());
+    }
+
+    let host = &args[1];
+    let username = &args[2];
+    let domain = &args[3];
+    let Ok(ntlm_hash) = args[4].as_str().parse() else {
+        eprintln!("Invalid NTLM hash format. Expected format: <hash>");
+        std::process::exit(1);
+    };
+
+    let base = domain_to_base(domain);
+
+    #[cfg(feature = "ntlm")]
+    {
+        let mut ldap = LdapConn::new(&format!("ldap://{host}:389"))?;
+
+        let res = ldap.sasl_ntlm_bind_with_hash(username, domain, &ntlm_hash)?;
+
+        if res.rc != 0 {
+            eprintln!("NTLM hash authentication failed: {res}");
+            return Err(res.into());
+        }
+
+        println!("[+] NTLM hash authentication successful");
+
+        let (entries, _) = ldap
+            .search(
+                &base,
+                ldap3::Scope::Subtree,
+                "(objectClass=person)",
+                vec!["cn", "name"],
+            )?
+            .success()?;
+
+        println!("[+] Num entries (objectClass=person): {:?}", entries.len());
+
+        ldap.unbind()?;
+    }
+
+    Ok(())
+}

--- a/examples/bind_sync_nthash.rs
+++ b/examples/bind_sync_nthash.rs
@@ -15,28 +15,28 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    env_logger::Builder::from_default_env()
-        .filter_level(log::LevelFilter::Debug)
-        .init();
-
-    let args = std::env::args().collect::<Vec<_>>();
-    if args.len() != 5 {
-        eprintln!("Usage: {} <host> <username> <domain> <ntlm_hash>", args[0]);
-        return Ok(());
-    }
-
-    let host = &args[1];
-    let username = &args[2];
-    let domain = &args[3];
-    let Ok(ntlm_hash) = args[4].as_str().parse() else {
-        eprintln!("Invalid NTLM hash format. Expected format: <hash>");
-        std::process::exit(1);
-    };
-
-    let base = domain_to_base(domain);
-
     #[cfg(feature = "ntlm")]
     {
+        env_logger::Builder::from_default_env()
+            .filter_level(log::LevelFilter::Debug)
+            .init();
+
+        let args = std::env::args().collect::<Vec<_>>();
+        if args.len() != 5 {
+            eprintln!("Usage: {} <host> <username> <domain> <ntlm_hash>", args[0]);
+            return Ok(());
+        }
+
+        let host = &args[1];
+        let username = &args[2];
+        let domain = &args[3];
+        let Ok(ntlm_hash) = args[4].as_str().parse() else {
+            eprintln!("Invalid NTLM hash format. Expected format: <hash>");
+            std::process::exit(1);
+        };
+
+        let base = domain_to_base(domain);
+
         let mut ldap = LdapConn::new(&format!("ldap://{host}:389"))?;
 
         let res = ldap.sasl_ntlm_bind_with_hash(username, domain, &ntlm_hash)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,3 +257,6 @@ pub use search::{
 #[cfg(feature = "sync")]
 pub use sync::{EntryStream, LdapConn};
 pub use util::{LdapUrlExt, LdapUrlParams, dn_escape, get_url_params, ldap_escape, ldap_unescape};
+
+#[cfg(feature = "ntlm")]
+pub use sspi::NtlmHash;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -129,6 +129,20 @@ impl LdapConn {
         rt.block_on(async move { ldap.sasl_ntlm_bind(username, password).await })
     }
 
+    #[cfg_attr(docsrs, doc(cfg(feature = "ntlm")))]
+    #[cfg(feature = "ntlm")]
+    /// See [`Ldap::sasl_ntlm_bind_with_hash()`](struct.Ldap.html#method.sasl_ntlm_bind_with_hash).
+    pub fn sasl_ntlm_bind_with_hash(
+        &mut self,
+        username: &str,
+        domain: &str,
+        hash: &crate::NtlmHash,
+    ) -> Result<LdapResult> {
+        let rt = &mut self.rt;
+        let ldap = &mut self.ldap;
+        rt.block_on(async move { ldap.sasl_ntlm_bind_with_hash(username, domain, hash).await })
+    }
+
     /// See [`Ldap::search()`](struct.Ldap.html#method.search).
     pub fn search<'a, S: AsRef<str> + Send + Sync + 'a, A: AsRef<[S]> + Send + Sync + 'a>(
         &mut self,


### PR DESCRIPTION
Support for authenticating using NT hashes was just recently merged to main https://github.com/Devolutions/sspi-rs/commit/21b45e16dcee7171cd9ae70df37cee8cdf41df0e

This PR adds a new `sasl_ntlm_bind_with_hash` method that allows authenticating using an NT hash

Resolves #140 

Marking as draft so I can swap the git dependency for the next release once it's published